### PR TITLE
Partial Dalli compatibility

### DIFF
--- a/lib/memcache.ex
+++ b/lib/memcache.ex
@@ -110,25 +110,30 @@ defmodule Memcache do
   """
   @spec start_link(Keyword.t, Keyword.t) :: GenServer.on_start
   def start_link(connection_options \\ [], options \\ []) do
-    memcache_options = [:ttl, :namespace, :key_coder]
-    shared_options = [:coder]
+    extra_opts = [:ttl, :namespace, :key_coder, :coder]
+    connection_options = Keyword.merge(@default_opts, connection_options)
+    |> Keyword.update!(:coder, &normalize_coder/1)
+    state = connection_options |> Keyword.take(extra_opts) |> Enum.into(%{})
 
-    connection_options = @default_opts
-      |> Keyword.merge(connection_options)
-      |> Keyword.update!(:coder, &normalize_coder/1)
-
-    state = connection_options
-      |> Keyword.take(memcache_options ++ shared_options)
-      |> Enum.into(%{})
-
-    connection_options = Keyword.drop(connection_options, memcache_options)
-
-    {:ok, pid} = Connection.start_link(connection_options, options)
+    {:ok, pid} = connection_options
+      |> add_flags
+      |> Keyword.drop(extra_opts)
+      |> Connection.start_link(options)
 
     state = Map.put(state, :connection, pid)
     Registry.associate(pid, state)
-    
+
     {:ok, pid}
+  end
+
+  # When we're using a serializer/coder, then we need to let Connection know to
+  # set the serialization bit when writing keys. For Dalli compat.
+  defp add_flags(opts) do
+    flags = case opts[:coder] do
+      {Memcache.Coder.Raw, _} -> 0
+      _ -> 1
+    end
+    Keyword.put(opts, :flags, flags)
   end
 
   @doc """

--- a/lib/memcache/connection.ex
+++ b/lib/memcache/connection.ex
@@ -54,9 +54,7 @@ defmodule Memcache.Connection do
   """
   @spec start_link(Keyword.t, Keyword.t) :: GenServer.on_start
   def start_link(connection_options \\ [], options \\ []) do
-    connection_options = connection_options
-      |> with_defaults
-      |> with_flags
+    connection_options = with_defaults(connection_options)
     Connection.start_link(__MODULE__, connection_options, options)
   end
 
@@ -70,19 +68,6 @@ defmodule Memcache.Connection do
   defp with_defaults(opts) do
     Keyword.merge(@default_opts, opts)
     |> Keyword.update!(:hostname, (&if is_binary(&1), do: String.to_char_list(&1), else: &1))
-  end
-
-  # For Dalli compatibility, we need to set the first bit of "flags" to 1 if
-  # a serializer (coder) is used when setting keys. We're going to precompute
-  # flags based on if a coder is used and store it in our state. See serialize/4
-  # for the other half of this.
-  defp with_flags(opts) do
-    {coder, opts} = Keyword.pop(opts, :coder)
-    flags = case coder do
-      {Memcache.Coder.Raw, _} -> 0
-      _ -> 1
-    end
-    Keyword.put(opts, :flags, flags)
   end
 
   @doc """


### PR DESCRIPTION
This is enough to get Memcachex compatible with Dalli when they are both using a similar serializer (e.g. JSON).  This only works if *all* they keys written by Dalli use the same serializer.  In other words, if you write some keys with the JSON serializer and some raw with Dalli, then you can't read the raw keys from Memcachex using the JSON coder.

In more other words, Memcachex sets the serialization bit when writing, but it doesn't look for one when reading (it will always use a coder if present).

All test pass, but I'm not sure how to add tests for this since it requires Dalli reading keys that Memcachex sets.

The code is small, but pretty hacky, I don't really like it, sorry.

Addresses issue #7.