### PR TITLE
Run mix formatter

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["*.exs", "{lib,test}/**/*.{ex,exs}"]
+]

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ provides a less restrictive API. See the
 ## Example
 
 ```elixir
-{ :ok, pid } = Memcache.start_link()
-{ :ok } = Memcache.set(pid, "hello", "world")
-{ :ok, "world" } = Memcache.get(pid, "hello")
+{:ok, pid} = Memcache.start_link()
+{:ok} = Memcache.set(pid, "hello", "world")
+{:ok, "world"} = Memcache.get(pid, "hello")
 ```
 
 See test folder for further examples.

--- a/bench.exs
+++ b/bench.exs
@@ -2,33 +2,40 @@ alias Memcache.Connection
 
 defmodule Utils do
   def random_string(size \\ 10000) do
-    :crypto.strong_rand_bytes(size) |> :base64.encode_to_string |> to_string
+    :crypto.strong_rand_bytes(size) |> :base64.encode_to_string() |> to_string
   end
 end
 
-{ :ok, mcd} = :mcd.start_link(['localhost', 11211])
-{ :ok, pid } = Connection.start_link([ hostname: "localhost" ])
-{ :ok, memcache } = Memcache.start_link([ hostname: "localhost" ])
-{ :ok } = Connection.execute(pid, :SET, ["hello", "world"])
+{:ok, mcd} = :mcd.start_link(['localhost', 11211])
+{:ok, pid} = Connection.start_link(hostname: "localhost")
+{:ok, memcache} = Memcache.start_link(hostname: "localhost")
+{:ok} = Connection.execute(pid, :SET, ["hello", "world"])
 large_blob = Utils.random_string()
-{ :ok } = Connection.execute(pid, :SET, ["hello_large", large_blob])
-getq_query = Enum.map(Range.new(1, 100), fn (_) -> {:GETQ, ["hello"]} end)
-setq_query = Enum.map(Range.new(1, 100), fn (_) -> {:SETQ, ["hello_large", Utils.random_string()]} end)
+{:ok} = Connection.execute(pid, :SET, ["hello_large", large_blob])
+getq_query = Enum.map(Range.new(1, 100), fn _ -> {:GETQ, ["hello"]} end)
+
+setq_query =
+  Enum.map(Range.new(1, 100), fn _ -> {:SETQ, ["hello_large", Utils.random_string()]} end)
 
 {:ok, _} = :mcd.set(mcd, "hello", "world")
 {:ok, _} = :mcd.set(mcd, "hello_large", large_blob)
 
-Benchee.run(%{
-  "sleep" => fn -> Process.sleep(100) end,
-  "Memcache.GET" => fn -> { :ok, "world" } = Memcache.get(memcache, "hello") end,
-  "Connection.GET" => fn -> { :ok, "world" } = Connection.execute(pid, :GET, ["hello"]) end,
-  "mcd.GET" => fn -> { :ok, "world" } = :mcd.get(mcd, "hello") end,
-  "Connection.SET" => fn -> { :ok } = Connection.execute(pid, :SET, ["hello", "world"]) end,
-  "mcd.SET" => fn -> { :ok, "world" } = :mcd.set(mcd, "hello", "world") end,
-  "Connection.SET LARGE" => fn -> { :ok } = Connection.execute(pid, :SET, ["hello_large", large_blob]) end,
-  "mcd.SET LARGE" => fn -> { :ok, _ } = :mcd.set(mcd, "hello_large", large_blob) end,
-  "Connection.GET LARGE" => fn -> { :ok, _ } = Connection.execute(pid, :GET, ["hello_large"]) end,
-  "mcd.GET LARGE" => fn -> { :ok, _ } = :mcd.get(mcd, "hello_large") end,
-  "Connection.GETQ" => fn -> Connection.execute_quiet(pid, getq_query) end,
-  "Connection.SETQ LARGE" => fn -> Connection.execute_quiet(pid, setq_query) end
-}, parallel: 1)
+Benchee.run(
+  %{
+    "sleep" => fn -> Process.sleep(100) end,
+    "Memcache.GET" => fn -> {:ok, "world"} = Memcache.get(memcache, "hello") end,
+    "Connection.GET" => fn -> {:ok, "world"} = Connection.execute(pid, :GET, ["hello"]) end,
+    "mcd.GET" => fn -> {:ok, "world"} = :mcd.get(mcd, "hello") end,
+    "Connection.SET" => fn -> {:ok} = Connection.execute(pid, :SET, ["hello", "world"]) end,
+    "mcd.SET" => fn -> {:ok, "world"} = :mcd.set(mcd, "hello", "world") end,
+    "Connection.SET LARGE" => fn ->
+      {:ok} = Connection.execute(pid, :SET, ["hello_large", large_blob])
+    end,
+    "mcd.SET LARGE" => fn -> {:ok, _} = :mcd.set(mcd, "hello_large", large_blob) end,
+    "Connection.GET LARGE" => fn -> {:ok, _} = Connection.execute(pid, :GET, ["hello_large"]) end,
+    "mcd.GET LARGE" => fn -> {:ok, _} = :mcd.get(mcd, "hello_large") end,
+    "Connection.GETQ" => fn -> Connection.execute_quiet(pid, getq_query) end,
+    "Connection.SETQ LARGE" => fn -> Connection.execute_quiet(pid, setq_query) end
+  },
+  parallel: 1
+)

--- a/lib/memcache/binary_utils.ex
+++ b/lib/memcache/binary_utils.ex
@@ -1,42 +1,42 @@
 defmodule Memcache.BinaryUtils do
   @moduledoc false
 
-  @ops  [
-         GET: 0x00,
-         SET: 0x01,
-         ADD: 0x02,
-         REPLACE: 0x03,
-         DELETE: 0x04,
-         INCREMENT: 0x05,
-         DECREMENT: 0x06,
-         QUIT: 0x07,
-         FLUSH: 0x08,
-         GETQ: 0x09,
-         NOOP: 0x0A,
-         VERSION: 0x0B,
-         GETK: 0x0C,
-         GETKQ: 0x0D,
-         APPEND: 0x0E,
-         PREPEND: 0x0F,
-         STAT: 0x10,
-         SETQ: 0x11,
-         ADDQ: 0x12,
-         REPLACEQ: 0x13,
-         DELETEQ: 0x14,
-         INCREMENTQ: 0x15,
-         DECREMENTQ: 0x16,
-         QUITQ: 0x17,
-         FLUSHQ: 0x18,
-         APPENDQ: 0x19,
-         PREPENDQ: 0x1A,
-         AUTH_LIST: 0x20,
-         AUTH_START: 0x21,
-         AUTH_STEP: 0x22
+  @ops [
+    GET: 0x00,
+    SET: 0x01,
+    ADD: 0x02,
+    REPLACE: 0x03,
+    DELETE: 0x04,
+    INCREMENT: 0x05,
+    DECREMENT: 0x06,
+    QUIT: 0x07,
+    FLUSH: 0x08,
+    GETQ: 0x09,
+    NOOP: 0x0A,
+    VERSION: 0x0B,
+    GETK: 0x0C,
+    GETKQ: 0x0D,
+    APPEND: 0x0E,
+    PREPEND: 0x0F,
+    STAT: 0x10,
+    SETQ: 0x11,
+    ADDQ: 0x12,
+    REPLACEQ: 0x13,
+    DELETEQ: 0x14,
+    INCREMENTQ: 0x15,
+    DECREMENTQ: 0x16,
+    QUITQ: 0x17,
+    FLUSHQ: 0x18,
+    APPENDQ: 0x19,
+    PREPENDQ: 0x1A,
+    AUTH_LIST: 0x20,
+    AUTH_START: 0x21,
+    AUTH_STEP: 0x22
   ]
 
   defmacro opb(x) do
     quote do
-      << unquote(Keyword.fetch!(@ops, x)) >>
+      <<unquote(Keyword.fetch!(@ops, x))>>
     end
   end
 
@@ -49,45 +49,53 @@ defmodule Memcache.BinaryUtils do
   defmodule Header do
     @moduledoc false
 
-    defstruct opcode: nil, key_length: nil, extra_length: nil, data_type: nil, status: nil, total_body_length: nil, opaque: nil, cas: nil
+    defstruct opcode: nil,
+              key_length: nil,
+              extra_length: nil,
+              data_type: nil,
+              status: nil,
+              total_body_length: nil,
+              opaque: nil,
+              cas: nil
   end
 
   defmacro defparse_empty(name) do
     quote do
-      def parse_body(%Header{ status: 0x0000, opcode: op(unquote(name)), opaque: opaque }, :empty) do
-        { opaque, { :ok }}
+      def parse_body(%Header{status: 0x0000, opcode: op(unquote(name)), opaque: opaque}, :empty) do
+        {opaque, {:ok}}
       end
     end
   end
 
   defmacro defparse_error(code, error) do
     quote do
-      def parse_body(%Header{ status: unquote(code), opaque: opaque }, _rest) do
-        { opaque, { :error, unquote(error) }}
+      def parse_body(%Header{status: unquote(code), opaque: opaque}, _rest) do
+        {opaque, {:error, unquote(error)}}
       end
     end
   end
 
   defmacro bcat(binaries) do
-    { parts, _ } = Code.eval_quoted(binaries, [], __CALLER__)
+    {parts, _} = Code.eval_quoted(binaries, [], __CALLER__)
+
     quote do
-      unquote(Enum.reduce(parts, <<>>, fn (x, a) -> a <> x end))
+      unquote(Enum.reduce(parts, <<>>, fn x, a -> a <> x end))
     end
   end
 
   defmacro request do
-    quote do: << 0x80 >>
+    quote do: <<0x80>>
   end
 
   defmacro reserved do
-    quote do: << 0x0000 :: size(16) >>
+    quote do: <<0x0000::size(16)>>
   end
 
   defmacro datatype do
-    quote do: << 0x00 >>
+    quote do: <<0x00>>
   end
 
   defmacro opaque do
-    quote do: << 0x00 :: size(32) >>
+    quote do: <<0x00::size(32)>>
   end
 end

--- a/lib/memcache/coder.ex
+++ b/lib/memcache/coder.ex
@@ -9,11 +9,11 @@ defmodule Memcache.Coder do
   Called before the value is sent to the server. It should return
   iodata.
   """
-  @callback encode(any, options :: Keyword.t) :: iodata
+  @callback encode(any, options :: Keyword.t()) :: iodata
 
   @doc """
   Called after the value is loaded from the server. It can return any
   type.
   """
-  @callback decode(iodata, options :: Keyword.t) :: any
+  @callback decode(iodata, options :: Keyword.t()) :: any
 end

--- a/lib/memcache/connection.ex
+++ b/lib/memcache/connection.ex
@@ -52,7 +52,7 @@ defmodule Memcache.Connection do
       {:ok, pid} = Memcache.Connection.start_link()
 
   """
-  @spec start_link(Keyword.t, Keyword.t) :: GenServer.on_start
+  @spec start_link(Keyword.t(), Keyword.t()) :: GenServer.on_start()
   def start_link(connection_options \\ [], options \\ []) do
     connection_options = with_defaults(connection_options)
     Connection.start_link(__MODULE__, connection_options, options)
@@ -66,8 +66,9 @@ defmodule Memcache.Connection do
   ]
 
   defp with_defaults(opts) do
-    Keyword.merge(@default_opts, opts)
-    |> Keyword.update!(:hostname, (&if is_binary(&1), do: String.to_char_list(&1), else: &1))
+    @default_opts
+    |> Keyword.merge(opts)
+    |> Keyword.update!(:hostname, &if(is_binary(&1), do: String.to_char_list(&1), else: &1))
   end
 
   @doc """
@@ -87,9 +88,9 @@ defmodule Memcache.Connection do
       {:ok, "world"}
 
   """
-  @spec execute(GenServer.server, atom, [binary], Keyword.t) :: Memcache.result
+  @spec execute(GenServer.server(), atom, [binary], Keyword.t()) :: Memcache.result()
   def execute(pid, command, args, options \\ []) do
-    Connection.call(pid, { :execute, command, args, %{cas: Keyword.get(options, :cas, false)} })
+    Connection.call(pid, {:execute, command, args, %{cas: Keyword.get(options, :cas, false)}})
   end
 
   @doc """
@@ -103,9 +104,10 @@ defmodule Memcache.Connection do
       {:ok, [{:ok, "one"}, {:ok, "two"}]}
 
   """
-  @spec execute_quiet(GenServer.server, [{atom, [binary]} | {atom, [binary], Keyword.t}]) :: {:ok, [Memcache.result]} | {:error, atom}
+  @spec execute_quiet(GenServer.server(), [{atom, [binary]} | {atom, [binary], Keyword.t()}]) ::
+          {:ok, [Memcache.result()]} | {:error, atom}
   def execute_quiet(pid, commands) do
-    Connection.call(pid, { :execute_quiet, commands })
+    Connection.call(pid, {:execute_quiet, commands})
   end
 
   @doc """
@@ -116,56 +118,90 @@ defmodule Memcache.Connection do
       iex> Memcache.Connection.close(pid)
       {:ok}
   """
-  @spec close(GenServer.server) :: {:ok}
+  @spec close(GenServer.server()) :: {:ok}
   def close(pid) do
     :ok = GenServer.stop(pid)
     {:ok}
   end
 
   def init(opts) do
-    { :connect, :init, %State{opts: opts} }
+    {:connect, :init, %State{opts: opts}}
   end
 
   def connect(info, %State{opts: opts} = s) do
     sock_opts = [:binary, active: false, packet: :raw]
+
     case connect_and_authenticate(opts[:hostname], opts[:port], sock_opts, s) do
-      { :ok, sock } ->
-        _ = if info == :backoff || info == :reconnect do
+      {:ok, sock} ->
+        _ =
+          if info == :backoff || info == :reconnect do
             Logger.info(["Reconnected to Memcache (", Utils.format_host(opts), ")"])
           end
-        { :ok, receiver } = Receiver.start_link([sock, self()])
+
+        {:ok, receiver} = Receiver.start_link([sock, self()])
         receiver_queue = MapSet.new()
-        state = %{s | sock: sock, backoff_current: nil, receiver: receiver, receiver_queue: receiver_queue }
-        { :ok, state }
-      { :error, reason } ->
+
+        state = %{
+          s
+          | sock: sock,
+            backoff_current: nil,
+            receiver: receiver,
+            receiver_queue: receiver_queue
+        }
+
+        {:ok, state}
+
+      {:error, reason} ->
         backoff = get_backoff(s)
-        _ = Logger.error(["Failed to connect to Memcache (", Utils.format_host(opts), "): ", Utils.format_error(reason), ". Sleeping for ", to_string(backoff), "ms."])
-        { :backoff, backoff, %{s | backoff_current: backoff} }
-      { :stop, reason } -> { :stop, reason, s }
+
+        _ =
+          Logger.error([
+            "Failed to connect to Memcache (",
+            Utils.format_host(opts),
+            "): ",
+            Utils.format_error(reason),
+            ". Sleeping for ",
+            to_string(backoff),
+            "ms."
+          ])
+
+        {:backoff, backoff, %{s | backoff_current: backoff}}
+
+      {:stop, reason} ->
+        {:stop, reason, s}
     end
   end
 
-  def disconnect({ :error, reason }, %State{ opts: opts } = s) do
-    _ = Logger.error(["Disconnected from Memcache (", Utils.format_host(opts), "): ", Utils.format_error(reason)])
+  def disconnect({:error, reason}, %State{opts: opts} = s) do
+    _ =
+      Logger.error([
+        "Disconnected from Memcache (",
+        Utils.format_host(opts),
+        "): ",
+        Utils.format_error(reason)
+      ])
+
     cleanup(s)
-    {:connect, :reconnect, %{s | sock: nil, backoff_current: nil, receiver: nil, receiver_queue: nil}}
+
+    {:connect, :reconnect,
+     %{s | sock: nil, backoff_current: nil, receiver: nil, receiver_queue: nil}}
   end
 
-  def handle_call({ :execute, _command, _args, _opts }, _from, %State{ sock: nil } = s) do
+  def handle_call({:execute, _command, _args, _opts}, _from, %State{sock: nil} = s) do
     {:reply, {:error, :closed}, s}
   end
 
-  def handle_call({ :execute, command, args, opts }, from, s) do
+  def handle_call({:execute, command, args, opts}, from, s) do
     with :ok <- maybe_deactivate_sock(s) do
       send_and_receive(s, from, command, args, opts)
     end
   end
 
-  def handle_call({ :execute_quiet, _commands }, _from, %State{ sock: nil } = s) do
+  def handle_call({:execute_quiet, _commands}, _from, %State{sock: nil} = s) do
     {:reply, {:error, :closed}, s}
   end
 
-  def handle_call({ :execute_quiet, commands }, from, s) do
+  def handle_call({:execute_quiet, commands}, from, s) do
     with :ok <- maybe_deactivate_sock(s) do
       send_and_receive_quiet(s, from, commands)
     end
@@ -173,16 +209,16 @@ defmodule Memcache.Connection do
 
   def handle_info({:tcp_closed, _socket}, state) do
     error = {:error, :closed}
-    { :disconnect, error, state }
+    {:disconnect, error, state}
   end
 
   def handle_info({:tcp_error, _socket, reason}, state) do
     error = {:error, reason}
-    { :disconnect, error, state }
+    {:disconnect, error, state}
   end
 
   def handle_info({:receiver, :disconnect, error, receiver}, %State{receiver: receiver} = state) do
-    { :disconnect, error, state }
+    {:disconnect, error, state}
   end
 
   def handle_info({:receiver, :done, client, receiver}, %State{receiver: receiver} = state) do
@@ -202,10 +238,11 @@ defmodule Memcache.Connection do
 
   ## Private ##
 
-  def cleanup(%State{ sock: sock, receiver: receiver, receiver_queue: receiver_queue}) do
+  def cleanup(%State{sock: sock, receiver: receiver, receiver_queue: receiver_queue}) do
     if sock do
       :ok = :gen_tcp.close(sock)
     end
+
     if receiver do
       try do
         Receiver.stop(receiver)
@@ -213,69 +250,80 @@ defmodule Memcache.Connection do
         :exit, _ -> :ok
       end
     end
+
     if receiver_queue do
       Enum.each(receiver_queue, fn from ->
         Connection.reply(from, {:error, :closed})
       end)
     end
+
     :ok
   end
 
   defp maybe_activate_sock(state) do
     if Enum.empty?(state.receiver_queue) do
-      case :inet.setopts(state.sock, [active: :once]) do
-        :ok -> { :noreply, state }
-        error -> { :disconnect, error, state }
+      case :inet.setopts(state.sock, active: :once) do
+        :ok -> {:noreply, state}
+        error -> {:disconnect, error, state}
       end
     else
-      { :noreply, state }
+      {:noreply, state}
     end
   end
 
   defp maybe_deactivate_sock(state) do
     if Enum.empty?(state.receiver_queue) do
-      case :inet.setopts(state.sock, [active: false]) do
+      case :inet.setopts(state.sock, active: false) do
         :ok -> :ok
-        error -> { :disconnect, error, {:error, :closed}, state }
+        error -> {:disconnect, error, {:error, :closed}, state}
       end
     else
       :ok
     end
   end
 
-  defp send_and_receive(%State{ sock: sock } = s, from, command, args, opts) do
+  defp send_and_receive(%State{sock: sock} = s, from, command, args, opts) do
     packet = serialize(command, args)
+
     case :gen_tcp.send(sock, packet) do
       :ok ->
         s = enqueue_receiver(s, from)
         :ok = Receiver.read(s.receiver, from, command, opts)
         {:noreply, s}
-      { :error, _reason } = error -> { :disconnect, error, error, s }
+
+      {:error, _reason} = error ->
+        {:disconnect, error, error, s}
     end
   end
 
-  defp send_and_receive_quiet(%State{ sock: sock } = s, from, commands) do
-    { packet, commands, i } = Enum.reduce(commands, { [], [], 1 }, &accumulate_commands/2)
+  defp send_and_receive_quiet(%State{sock: sock} = s, from, commands) do
+    {packet, commands, i} = Enum.reduce(commands, {[], [], 1}, &accumulate_commands/2)
     packet = [packet | serialize(:NOOP, [], i)]
+
     case :gen_tcp.send(sock, packet) do
       :ok ->
         s = enqueue_receiver(s, from)
-        :ok = Receiver.read_quiet(s.receiver, from, Enum.reverse([ { i, :NOOP, [], [] } | commands]))
+        :ok = Receiver.read_quiet(s.receiver, from, Enum.reverse([{i, :NOOP, [], []} | commands]))
         {:noreply, s}
-      { :error, _reason } = error -> { :disconnect, error, error, s }
+
+      {:error, _reason} = error ->
+        {:disconnect, error, error, s}
     end
   end
 
   defp enqueue_receiver(state, from) do
     receiver_queue = MapSet.put(state.receiver_queue, from)
-    %{state| receiver_queue: receiver_queue}
+    %{state | receiver_queue: receiver_queue}
   end
 
-  defp accumulate_commands({ command, args }, { packet, commands, i }) do
-    { [packet | serialize(command, args, i)], [{ i, command, args, %{cas: false} } | commands], i + 1 }
+  defp accumulate_commands({command, args}, {packet, commands, i}) do
+    {[packet | serialize(command, args, i)], [{i, command, args, %{cas: false}} | commands],
+     i + 1}
   end
-  defp accumulate_commands({ command, args, options }, { packet, commands, i }) do
-    { [packet | serialize(command, args, i)], [{ i, command, args, %{cas: Keyword.get(options, :cas, false)}} | commands], i + 1 }
+
+  defp accumulate_commands({command, args, options}, {packet, commands, i}) do
+    {[packet | serialize(command, args, i)],
+     [{i, command, args, %{cas: Keyword.get(options, :cas, false)}} | commands], i + 1}
   end
 
   defp get_backoff(s) do
@@ -292,14 +340,16 @@ defmodule Memcache.Connection do
         with {:ok} <- authenticate(sock, state.opts),
              # Make sure the socket is usable
              {:ok, _} <- execute_command(sock, :NOOP, []),
-             :ok <- :inet.setopts(sock, [active: :once]) do
+             :ok <- :inet.setopts(sock, active: :once) do
           {:ok, sock}
         else
           error ->
             :gen_tcp.close(sock)
             error
         end
-      error -> error
+
+      error ->
+        error
     end
   end
 
@@ -313,6 +363,7 @@ defmodule Memcache.Connection do
 
   defp execute_command(sock, command, args) do
     packet = serialize(command, args)
+
     case :gen_tcp.send(sock, packet) do
       :ok -> recv_response(sock, command)
       error -> error
@@ -323,25 +374,35 @@ defmodule Memcache.Connection do
     case execute_command(sock, :AUTH_LIST, []) do
       {:ok, {:ok, list}} ->
         supported = String.split(list, " ")
+
         if !Enum.member?(supported, "PLAIN") do
           {:stop, "Server doesn't support PLAIN authentication"}
         else
           auth_plain_continue(sock, username, password)
         end
+
       {:ok, {:error, "Unknown command"}} ->
-        _ = Logger.warn "Authentication not required/supported by server"
+        _ = Logger.warn("Authentication not required/supported by server")
         {:ok}
-      {:ok, {:error, reason}} -> {:stop, reason}
-      error -> error
+
+      {:ok, {:error, reason}} ->
+        {:stop, reason}
+
+      error ->
+        error
     end
   end
 
   defp auth_plain_continue(sock, username, password) do
     case execute_command(sock, :AUTH_START, ["PLAIN", "\0#{username}\0#{password}"]) do
-      {:ok, {:ok}} -> {:ok}
+      {:ok, {:ok}} ->
+        {:ok}
+
       {:ok, {:error, reason}} ->
         {:stop, reason}
-      error -> error
+
+      error ->
+        error
     end
   end
 

--- a/lib/memcache/protocol.ex
+++ b/lib/memcache/protocol.ex
@@ -7,61 +7,97 @@ defmodule Memcache.Protocol do
 
   def to_binary(:QUIT, opaque) do
     [
-      bcat([ request, opb(:QUIT), << 0x00 :: size(16) >>,
-             << 0x00 >>, datatype, reserved,
-             << 0x00 :: size(32) >> ]),
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>
+      bcat([
+        request(),
+        opb(:QUIT),
+        <<0x00::size(16)>>,
+        <<0x00>>,
+        datatype(),
+        reserved(),
+        <<0x00::size(32)>>
+      ]),
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>
     ]
   end
 
   def to_binary(:QUITQ, opaque) do
     [
-      bcat([ request, opb(:QUITQ), << 0x00 :: size(16) >>,
-             << 0x00 >>, datatype, reserved,
-             << 0x00 :: size(32) >> ]),
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>
+      bcat([
+        request(),
+        opb(:QUITQ),
+        <<0x00::size(16)>>,
+        <<0x00>>,
+        datatype(),
+        reserved(),
+        <<0x00::size(32)>>
+      ]),
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>
     ]
   end
 
   def to_binary(:NOOP, opaque) do
     [
-      bcat([ request, opb(:NOOP), << 0x00 :: size(16) >>,
-             << 0x00 >>, datatype, reserved,
-             << 0x00 :: size(32) >> ]),
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>
+      bcat([
+        request(),
+        opb(:NOOP),
+        <<0x00::size(16)>>,
+        <<0x00>>,
+        datatype(),
+        reserved(),
+        <<0x00::size(32)>>
+      ]),
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>
     ]
   end
 
   def to_binary(:VERSION, opaque) do
     [
-      bcat([ request, opb(:VERSION), << 0x00 :: size(16) >>,
-             << 0x00 >>, datatype, reserved,
-             << 0x00 :: size(32) >> ]),
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>
+      bcat([
+        request(),
+        opb(:VERSION),
+        <<0x00::size(16)>>,
+        <<0x00>>,
+        datatype(),
+        reserved(),
+        <<0x00::size(32)>>
+      ]),
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>
     ]
   end
 
   def to_binary(:STAT, opaque) do
     [
-      bcat([ request, opb(:STAT), << 0x00 :: size(16) >>,
-             << 0x00 >>, datatype, reserved,
-             << 0x00 :: size(32) >> ]),
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>
+      bcat([
+        request(),
+        opb(:STAT),
+        <<0x00::size(16)>>,
+        <<0x00>>,
+        datatype(),
+        reserved(),
+        <<0x00::size(32)>>
+      ]),
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>
     ]
   end
 
   def to_binary(:AUTH_LIST, opaque) do
     [
-      bcat([ request, opb(:AUTH_LIST), << 0x00 :: size(16) >>,
-             << 0x00 >>, datatype, reserved,
-             << 0x00 :: size(32) >> ]),
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>
+      bcat([
+        request(),
+        opb(:AUTH_LIST),
+        <<0x00::size(16)>>,
+        <<0x00>>,
+        datatype(),
+        reserved(),
+        <<0x00::size(32)>>
+      ]),
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>
     ]
   end
 
@@ -71,95 +107,106 @@ defmodule Memcache.Protocol do
 
   def to_binary(:STAT, opaque, key) do
     [
-      bcat([ request, opb(:STAT)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>,
+      bcat([request(), opb(:STAT)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>,
       key
     ]
   end
 
   def to_binary(:GET, opaque, key) do
     [
-      bcat([ request, opb(:GET)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>,
+      bcat([request(), opb(:GET)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>,
       key
     ]
   end
 
   def to_binary(:GETQ, opaque, key) do
     [
-      bcat([ request, opb(:GETQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>,
+      bcat([request(), opb(:GETQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>,
       key
     ]
   end
 
   def to_binary(:GETK, opaque, key) do
     [
-      bcat([ request, opb(:GETK)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>,
+      bcat([request(), opb(:GETK)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>,
       key
     ]
   end
 
   def to_binary(:GETKQ, opaque, key) do
     [
-      bcat([ request, opb(:GETKQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>,
+      bcat([request(), opb(:GETKQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>,
       key
     ]
   end
 
   def to_binary(:FLUSH, opaque, expiry) do
     [
-      bcat([ request, opb(:FLUSH), << 0x00 :: size(16) >>,
-             << 0x04 >>, datatype, reserved,
-             << 0x04 :: size(32) >>]),
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>,
-      << expiry :: size(32) >>
+      bcat([
+        request(),
+        opb(:FLUSH),
+        <<0x00::size(16)>>,
+        <<0x04>>,
+        datatype(),
+        reserved(),
+        <<0x04::size(32)>>
+      ]),
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>,
+      <<expiry::size(32)>>
     ]
   end
 
   def to_binary(:FLUSHQ, opaque, expiry) do
     [
-      bcat([ request, opb(:FLUSHQ), << 0x00 :: size(16) >>,
-             << 0x04 >>, datatype, reserved,
-             << 0x04 :: size(32) >>]),
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>,
-      << expiry :: size(32) >>
+      bcat([
+        request(),
+        opb(:FLUSHQ),
+        <<0x00::size(16)>>,
+        <<0x04>>,
+        datatype(),
+        reserved(),
+        <<0x04::size(32)>>
+      ]),
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>,
+      <<expiry::size(32)>>
     ]
   end
 
-
   def to_binary(:AUTH_START, opaque, key) do
     [
-      bcat([ request, opb(:AUTH_START)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>,
+      bcat([request(), opb(:AUTH_START)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>,
       key
     ]
   end
@@ -170,12 +217,12 @@ defmodule Memcache.Protocol do
 
   def to_binary(:AUTH_START, opaque, key, value) do
     [
-      bcat([ request, opb(:AUTH_START)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << 0x00 :: size(64) >>,
+      bcat([request(), opb(:AUTH_START)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key) + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<0x00::size(64)>>,
       key,
       value
     ]
@@ -183,24 +230,24 @@ defmodule Memcache.Protocol do
 
   def to_binary(:DELETE, opaque, key, cas) do
     [
-      bcat([ request, opb(:DELETE)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >> ,
+      bcat([request(), opb(:DELETE)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
       key
     ]
   end
 
   def to_binary(:DELETEQ, opaque, key, cas) do
     [
-      bcat([ request, opb(:DELETEQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
+      bcat([request(), opb(:DELETEQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
       key
     ]
   end
@@ -211,12 +258,12 @@ defmodule Memcache.Protocol do
 
   def to_binary(:APPEND, opaque, key, value, cas) do
     [
-      bcat([ request, opb(:APPEND)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
+      bcat([request(), opb(:APPEND)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key) + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
       key,
       value
     ]
@@ -224,12 +271,12 @@ defmodule Memcache.Protocol do
 
   def to_binary(:APPENDQ, opaque, key, value, cas) do
     [
-      bcat([ request, opb(:APPENDQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
+      bcat([request(), opb(:APPENDQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key) + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
       key,
       value
     ]
@@ -237,12 +284,12 @@ defmodule Memcache.Protocol do
 
   def to_binary(:PREPEND, opaque, key, value, cas) do
     [
-      bcat([ request, opb(:PREPEND)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
+      bcat([request(), opb(:PREPEND)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key) + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
       key,
       value
     ]
@@ -250,12 +297,12 @@ defmodule Memcache.Protocol do
 
   def to_binary(:PREPENDQ, opaque, key, value, cas) do
     [
-      bcat([ request, opb(:PREPENDQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x00 >>, datatype, reserved]),
-      << byte_size(key) + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
+      bcat([request(), opb(:PREPENDQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x00>>, datatype(), reserved()]),
+      <<byte_size(key) + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
       key,
       value
     ]
@@ -265,81 +312,80 @@ defmodule Memcache.Protocol do
     to_binary(command, opaque, key, value, cas, 0)
   end
 
-
   def to_binary(command, opaque, key, value, cas, flag) do
     to_binary(command, opaque, key, value, cas, flag, 0)
   end
 
   def to_binary(:INCREMENT, opaque, key, delta, initial, cas, expiry) do
     [
-      bcat([ request, opb(:INCREMENT)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x14 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 20 :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << delta :: size(64) >>,
-      << initial :: size(64) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:INCREMENT)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x14>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 20::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<delta::size(64)>>,
+      <<initial::size(64)>>,
+      <<expiry::size(32)>>,
       key
     ]
   end
 
   def to_binary(:INCREMENTQ, opaque, key, delta, initial, cas, expiry) do
     [
-      bcat([ request, opb(:INCREMENTQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x14 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 20 :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << delta :: size(64) >>,
-      << initial :: size(64) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:INCREMENTQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x14>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 20::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<delta::size(64)>>,
+      <<initial::size(64)>>,
+      <<expiry::size(32)>>,
       key
     ]
   end
 
   def to_binary(:DECREMENT, opaque, key, delta, initial, cas, expiry) do
     [
-      bcat([ request, opb(:DECREMENT)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x14 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 20 :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << delta :: size(64) >>,
-      << initial :: size(64) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:DECREMENT)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x14>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 20::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<delta::size(64)>>,
+      <<initial::size(64)>>,
+      <<expiry::size(32)>>,
       key
     ]
   end
 
   def to_binary(:DECREMENTQ, opaque, key, delta, initial, cas, expiry) do
     [
-      bcat([ request, opb(:DECREMENTQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x14 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 20 :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << delta :: size(64) >>,
-      << initial :: size(64) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:DECREMENTQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x14>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 20::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<delta::size(64)>>,
+      <<initial::size(64)>>,
+      <<expiry::size(32)>>,
       key
     ]
   end
 
   def to_binary(:SET, opaque, key, value, cas, expiry, flag) do
     [
-      bcat([ request, opb(:SET)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x08 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 8 + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << flag :: size(32) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:SET)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x08>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 8 + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<flag::size(32)>>,
+      <<expiry::size(32)>>,
       key,
       value
     ]
@@ -347,14 +393,14 @@ defmodule Memcache.Protocol do
 
   def to_binary(:SETQ, opaque, key, value, cas, expiry, flag) do
     [
-      bcat([ request, opb(:SETQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x08 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 8 + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << flag :: size(32) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:SETQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x08>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 8 + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<flag::size(32)>>,
+      <<expiry::size(32)>>,
       key,
       value
     ]
@@ -362,14 +408,14 @@ defmodule Memcache.Protocol do
 
   def to_binary(:ADD, opaque, key, value, expiry, cas, flag) do
     [
-      bcat([ request, opb(:ADD)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x08 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 8 + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << flag :: size(32) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:ADD)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x08>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 8 + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<flag::size(32)>>,
+      <<expiry::size(32)>>,
       key,
       value
     ]
@@ -377,14 +423,14 @@ defmodule Memcache.Protocol do
 
   def to_binary(:ADDQ, opaque, key, value, cas, expiry, flag) do
     [
-      bcat([ request, opb(:ADDQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x08 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 8 + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << flag :: size(32) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:ADDQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x08>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 8 + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<flag::size(32)>>,
+      <<expiry::size(32)>>,
       key,
       value
     ]
@@ -392,14 +438,14 @@ defmodule Memcache.Protocol do
 
   def to_binary(:REPLACE, opaque, key, value, cas, expiry, flag) do
     [
-      bcat([ request, opb(:REPLACE)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x08 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 8 + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << flag :: size(32) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:REPLACE)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x08>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 8 + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<flag::size(32)>>,
+      <<expiry::size(32)>>,
       key,
       value
     ]
@@ -407,105 +453,176 @@ defmodule Memcache.Protocol do
 
   def to_binary(:REPLACEQ, opaque, key, value, cas, expiry, flag) do
     [
-      bcat([ request, opb(:REPLACEQ)]),
-      << byte_size(key) :: size(16) >>,
-      bcat([<< 0x08 >>, << 0x00 >>, << 0x0000 :: size(16) >>]),
-      << byte_size(key) + 8 + IO.iodata_length(value) :: size(32) >>,
-      << opaque :: size(32) >>,
-      << cas :: size(64) >>,
-      << flag :: size(32) >>,
-      << expiry :: size(32) >>,
+      bcat([request(), opb(:REPLACEQ)]),
+      <<byte_size(key)::size(16)>>,
+      bcat([<<0x08>>, <<0x00>>, <<0x0000::size(16)>>]),
+      <<byte_size(key) + 8 + IO.iodata_length(value)::size(32)>>,
+      <<opaque::size(32)>>,
+      <<cas::size(64)>>,
+      <<flag::size(32)>>,
+      <<expiry::size(32)>>,
       key,
       value
     ]
   end
 
   def parse_header(<<
-                   0x81 :: size(8),
-                   opcode :: size(8),
-                   key_length :: size(16),
-                   extra_length :: size(8),
-                   data_type :: size(8),
-                   status :: size(16),
-                   total_body_length :: size(32),
-                   opaque :: size(32),
-                   cas :: size(64)
-                   >>) do
-    %Header{ opcode: opcode, key_length: key_length, extra_length: extra_length, data_type: data_type, status: status, total_body_length: total_body_length, opaque: opaque, cas: cas }
+        0x81::size(8),
+        opcode::size(8),
+        key_length::size(16),
+        extra_length::size(8),
+        data_type::size(8),
+        status::size(16),
+        total_body_length::size(32),
+        opaque::size(32),
+        cas::size(64)
+      >>) do
+    %Header{
+      opcode: opcode,
+      key_length: key_length,
+      extra_length: extra_length,
+      data_type: data_type,
+      status: status,
+      total_body_length: total_body_length,
+      opaque: opaque,
+      cas: cas
+    }
   end
 
   def total_body_size(%Header{total_body_length: size}) do
     size
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:GET), extra_length: extra_length, total_body_length: total_body_length, opaque: opaque }, rest) do
-    value_size = (total_body_length - extra_length)
-    << _extra :: binary-size(extra_length),  value :: binary-size(value_size) >> = rest
-    { opaque, { :ok, value } }
+  def parse_body(
+        %Header{
+          status: 0x0000,
+          opcode: op(:GET),
+          extra_length: extra_length,
+          total_body_length: total_body_length,
+          opaque: opaque
+        },
+        rest
+      ) do
+    value_size = total_body_length - extra_length
+    <<_extra::binary-size(extra_length), value::binary-size(value_size)>> = rest
+    {opaque, {:ok, value}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:GETQ), extra_length: extra_length, total_body_length: total_body_length, opaque: opaque }, rest) do
-    value_size = (total_body_length - extra_length)
-    << _extra :: binary-size(extra_length),  value :: binary-size(value_size) >> = rest
-    { opaque, { :ok, value } }
+  def parse_body(
+        %Header{
+          status: 0x0000,
+          opcode: op(:GETQ),
+          extra_length: extra_length,
+          total_body_length: total_body_length,
+          opaque: opaque
+        },
+        rest
+      ) do
+    value_size = total_body_length - extra_length
+    <<_extra::binary-size(extra_length), value::binary-size(value_size)>> = rest
+    {opaque, {:ok, value}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:GETK), extra_length: extra_length, key_length: key_length, total_body_length: total_body_length, opaque: opaque }, rest) do
-    value_size = (total_body_length - extra_length - key_length)
-    << _extra :: binary-size(extra_length), key :: binary-size(key_length), value :: binary-size(value_size) >> = rest
-    { opaque, { :ok, key, value } }
+  def parse_body(
+        %Header{
+          status: 0x0000,
+          opcode: op(:GETK),
+          extra_length: extra_length,
+          key_length: key_length,
+          total_body_length: total_body_length,
+          opaque: opaque
+        },
+        rest
+      ) do
+    value_size = total_body_length - extra_length - key_length
+
+    <<_extra::binary-size(extra_length), key::binary-size(key_length),
+      value::binary-size(value_size)>> = rest
+
+    {opaque, {:ok, key, value}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:GETKQ), extra_length: extra_length, key_length: key_length, total_body_length: total_body_length, opaque: opaque }, rest) do
-    value_size = (total_body_length - extra_length - key_length)
-    << _extra :: binary-size(extra_length), key :: binary-size(key_length), value :: binary-size(value_size) >> = rest
-    { opaque, { :ok, key, value }}
+  def parse_body(
+        %Header{
+          status: 0x0000,
+          opcode: op(:GETKQ),
+          extra_length: extra_length,
+          key_length: key_length,
+          total_body_length: total_body_length,
+          opaque: opaque
+        },
+        rest
+      ) do
+    value_size = total_body_length - extra_length - key_length
+
+    <<_extra::binary-size(extra_length), key::binary-size(key_length),
+      value::binary-size(value_size)>> = rest
+
+    {opaque, {:ok, key, value}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:VERSION), opaque: opaque }, rest) do
-    { opaque, { :ok, rest } }
+  def parse_body(%Header{status: 0x0000, opcode: op(:VERSION), opaque: opaque}, rest) do
+    {opaque, {:ok, rest}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:AUTH_LIST), opaque: opaque }, rest) do
-    { opaque, { :ok, rest }}
+  def parse_body(%Header{status: 0x0000, opcode: op(:AUTH_LIST), opaque: opaque}, rest) do
+    {opaque, {:ok, rest}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:INCREMENT), opaque: opaque}, rest) do
-    << value :: size(64) >> = rest
-    { opaque, { :ok, value }}
+  def parse_body(%Header{status: 0x0000, opcode: op(:INCREMENT), opaque: opaque}, rest) do
+    <<value::size(64)>> = rest
+    {opaque, {:ok, value}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:INCREMENTQ), opaque: opaque }, rest) do
-    << value :: size(64) >> = rest
-    { opaque, { :ok, value }}
+  def parse_body(%Header{status: 0x0000, opcode: op(:INCREMENTQ), opaque: opaque}, rest) do
+    <<value::size(64)>> = rest
+    {opaque, {:ok, value}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:DECREMENT), opaque: opaque }, rest) do
-    << value :: size(64) >> = rest
-    { opaque, { :ok, value }}
+  def parse_body(%Header{status: 0x0000, opcode: op(:DECREMENT), opaque: opaque}, rest) do
+    <<value::size(64)>> = rest
+    {opaque, {:ok, value}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:DECREMENTQ), opaque: opaque }, rest) do
-    << value :: size(64) >> = rest
-    { opaque, { :ok, value }}
+  def parse_body(%Header{status: 0x0000, opcode: op(:DECREMENTQ), opaque: opaque}, rest) do
+    <<value::size(64)>> = rest
+    {opaque, {:ok, value}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:AUTH_START), opaque: opaque}, _rest) do
-    { opaque, { :ok }}
+  def parse_body(%Header{status: 0x0000, opcode: op(:AUTH_START), opaque: opaque}, _rest) do
+    {opaque, {:ok}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:STAT), key_length: 0, total_body_length: 0, opaque: opaque }, _rest) do
-    { opaque, { :ok, :done }}
+  def parse_body(
+        %Header{
+          status: 0x0000,
+          opcode: op(:STAT),
+          key_length: 0,
+          total_body_length: 0,
+          opaque: opaque
+        },
+        _rest
+      ) do
+    {opaque, {:ok, :done}}
   end
 
-  def parse_body(%Header{ status: 0x0000, opcode: op(:STAT), key_length: key_length, total_body_length: total_body_length, opaque: opaque }, rest) do
-    value_size = (total_body_length - key_length)
-    << key :: binary-size(key_length),  value :: binary-size(value_size) >> = rest
-    { opaque, { :ok, key, value } }
+  def parse_body(
+        %Header{
+          status: 0x0000,
+          opcode: op(:STAT),
+          key_length: key_length,
+          total_body_length: total_body_length,
+          opaque: opaque
+        },
+        rest
+      ) do
+    value_size = total_body_length - key_length
+    <<key::binary-size(key_length), value::binary-size(value_size)>> = rest
+    {opaque, {:ok, key, value}}
   end
 
-  def parse_body(%Header{ status: 0x0021, opaque: opaque }, body) do
-    { opaque, { :error, :auth_step, body } }
+  def parse_body(%Header{status: 0x0021, opaque: opaque}, body) do
+    {opaque, {:error, :auth_step, body}}
   end
 
   defparse_empty(:SET)
@@ -530,17 +647,16 @@ defmodule Memcache.Protocol do
   defparse_error(0x0081, "Unknown command")
   defparse_error(0x0082, "Out of memory")
 
-  def quiet_response(:GETQ), do: { :error, "Key not found" }
-  def quiet_response(:GETKQ), do: { :error, "Key not found" }
-  def quiet_response(:SETQ), do: { :ok }
-  def quiet_response(:ADDQ), do: { :ok }
-  def quiet_response(:DELETEQ), do: { :ok }
-  def quiet_response(:REPLACEQ), do: { :ok }
-  def quiet_response(:INCREMENTQ), do: { :ok }
-  def quiet_response(:DECREMENTQ), do: { :ok }
-  def quiet_response(:APPENDQ), do: { :ok }
-  def quiet_response(:PREPENDQ), do: { :ok }
-  def quiet_response(:FLUSHQ), do: { :ok }
-  def quiet_response(:QUITQ), do: { :ok }
-
+  def quiet_response(:GETQ), do: {:error, "Key not found"}
+  def quiet_response(:GETKQ), do: {:error, "Key not found"}
+  def quiet_response(:SETQ), do: {:ok}
+  def quiet_response(:ADDQ), do: {:ok}
+  def quiet_response(:DELETEQ), do: {:ok}
+  def quiet_response(:REPLACEQ), do: {:ok}
+  def quiet_response(:INCREMENTQ), do: {:ok}
+  def quiet_response(:DECREMENTQ), do: {:ok}
+  def quiet_response(:APPENDQ), do: {:ok}
+  def quiet_response(:PREPENDQ), do: {:ok}
+  def quiet_response(:FLUSHQ), do: {:ok}
+  def quiet_response(:QUITQ), do: {:ok}
 end

--- a/lib/memcache/receiver.ex
+++ b/lib/memcache/receiver.ex
@@ -42,22 +42,23 @@ defmodule Memcache.Receiver do
     send(s.parent, {:receiver, :done, client, self()})
     {:noreply, %{s | buffer: buffer}}
   end
+
   defp reply_or_disconnect(error, _client, s) do
     send(s.parent, {:receiver, :disconnect, error, self()})
     {:stop, :normal, s}
   end
 
   def recv_response(:STAT, sock, buffer, _opts) do
-    recv_stat(sock, buffer, Map.new)
+    recv_stat(sock, buffer, Map.new())
   end
 
   def recv_response(_command, sock, buffer, %{cas: cas}) do
     with {:ok, header, buffer} <- recv_header(sock, buffer),
          {:ok, response, buffer} <- recv_body(header, sock, buffer) do
       if cas do
-        { :ok, append_cas_version(response, header), buffer }
+        {:ok, append_cas_version(response, header), buffer}
       else
-        { :ok, response, buffer }
+        {:ok, response, buffer}
       end
     end
   end
@@ -70,27 +71,28 @@ defmodule Memcache.Receiver do
 
   defp recv_header(sock, buffer) do
     with {:ok, raw_header, buffer} <- read(sock, buffer, 24) do
-      { :ok, Protocol.parse_header(raw_header), buffer }
+      {:ok, Protocol.parse_header(raw_header), buffer}
     end
   end
 
   defp recv_body(header, sock, buffer) do
     body_size = Protocol.total_body_size(header)
+
     if body_size > 0 do
       with {:ok, body, buffer} <- read(sock, buffer, body_size) do
         response = Protocol.parse_body(header, body) |> elem(1)
-        { :ok, response, buffer}
+        {:ok, response, buffer}
       end
     else
       response = Protocol.parse_body(header, :empty) |> elem(1)
-      { :ok, response, buffer}
+      {:ok, response, buffer}
     end
   end
 
   defp recv_stat(sock, buffer, results) do
     case recv_header_and_body(sock, buffer) do
-      { :ok, { :ok, :done }, buffer } -> { :ok, { :ok, results }, buffer }
-      { :ok, { :ok, key, val }, buffer } -> recv_stat(sock, buffer, Map.put(results, key, val))
+      {:ok, {:ok, :done}, buffer} -> {:ok, {:ok, results}, buffer}
+      {:ok, {:ok, key, val}, buffer} -> recv_stat(sock, buffer, Map.put(results, key, val))
       err -> err
     end
   end
@@ -100,51 +102,66 @@ defmodule Memcache.Receiver do
   defp append_cas_version(error, %{cas: _cas_version}), do: error
 
   defp recv_response_quiet([], _sock, results, buffer) do
-    { :ok, { :ok, Enum.reverse(tl(results)) }, buffer }
+    {:ok, {:ok, Enum.reverse(tl(results))}, buffer}
   end
+
   defp recv_response_quiet(commands, sock, results, buffer) do
     with {:ok, header_raw, rest} <- read(sock, buffer, 24) do
       header = Protocol.parse_header(header_raw)
       body_size = Protocol.total_body_size(header)
+
       if body_size > 0 do
         case read(sock, rest, body_size) do
-          { :ok, body, rest } ->
-            { rest_commands, results } = match_response(commands, results, header, Protocol.parse_body(header, body))
+          {:ok, body, rest} ->
+            {rest_commands, results} =
+              match_response(commands, results, header, Protocol.parse_body(header, body))
+
             recv_response_quiet(rest_commands, sock, results, rest)
-          err -> err
+
+          err ->
+            err
         end
       else
-        { rest_commands, results } = match_response(commands, results, header, Protocol.parse_body(header, :empty))
+        {rest_commands, results} =
+          match_response(commands, results, header, Protocol.parse_body(header, :empty))
+
         recv_response_quiet(rest_commands, sock, results, rest)
       end
     end
   end
 
-  defp match_response([ { i, _command, _args, %{cas: true} } | rest ], results, header, { i, response }) do
-    { rest, [append_cas_version(response, header) | results] }
+  defp match_response([{i, _command, _args, %{cas: true}} | rest], results, header, {i, response}) do
+    {rest, [append_cas_version(response, header) | results]}
   end
-  defp match_response([ { i, _command, _args, _opts } | rest ], results, _header, { i, response }) do
-    { rest, [response | results] }
+
+  defp match_response([{i, _command, _args, _opts} | rest], results, _header, {i, response}) do
+    {rest, [response | results]}
   end
-  defp match_response([ { _i , command, _args, _opts } | rest ], results, header, response_with_index) do
-    match_response(rest, [Protocol.quiet_response(command) | results], header, response_with_index)
+
+  defp match_response([{_i, command, _args, _opts} | rest], results, header, response_with_index) do
+    match_response(
+      rest,
+      [Protocol.quiet_response(command) | results],
+      header,
+      response_with_index
+    )
   end
 
   defp read(_sock, buffer, min_required) when byte_size(buffer) >= min_required do
-    { requested, rest } = cut(buffer, min_required)
-    { :ok, requested, rest}
+    {requested, rest} = cut(buffer, min_required)
+    {:ok, requested, rest}
   end
 
   defp read(sock, buffer, min_required) do
     case :gen_tcp.recv(sock, 0) do
-      { :ok, data } -> read(sock, buffer <> data, min_required)
-      { :error, reason } -> { :error, reason }
+      {:ok, data} -> read(sock, buffer <> data, min_required)
+      {:error, reason} -> {:error, reason}
     end
   end
 
   defp cut(bin, at) do
     first = binary_part(bin, 0, at)
     rest = binary_part(bin, at, byte_size(bin) - at)
-    { first, rest }
+    {first, rest}
   end
 end

--- a/lib/memcache/registry.ex
+++ b/lib/memcache/registry.ex
@@ -6,7 +6,7 @@ defmodule Memcache.Registry do
   ## Public interface
 
   def start_link() do
-    GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   def associate(pid, value) when is_pid(pid) do
@@ -16,6 +16,7 @@ defmodule Memcache.Registry do
   def lookup(pid) when is_pid(pid) do
     :ets.lookup_element(__MODULE__, pid, 3)
   end
+
   def lookup(name) do
     lookup(GenServer.whereis(name))
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,30 +4,30 @@ defmodule Memcache.Mixfile do
   @version "0.4.2"
 
   def project do
-    [app: :memcachex,
-     version: @version,
-     elixir: ">= 1.3.0",
-     description: "Memcached client",
-     package: package(),
-     docs: docs(),
-     dialyzer: [
-       plt_add_deps: :transitive,
-       ignore_warnings: ".dialyzer_ignore",
-       flags: [:unmatched_returns, :race_conditions, :error_handling, :underspecs]
-     ],
-     deps: deps()]
+    [
+      app: :memcachex,
+      version: @version,
+      elixir: ">= 1.3.0",
+      description: "Memcached client",
+      package: package(),
+      docs: docs(),
+      dialyzer: [
+        plt_add_deps: :transitive,
+        ignore_warnings: ".dialyzer_ignore",
+        flags: [:unmatched_returns, :race_conditions, :error_handling, :underspecs]
+      ],
+      deps: deps()
+    ]
   end
 
   def application do
-    [applications: [:logger, :connection],
-     mod: {Memcache.Application, []}]
+    [applications: [:logger, :connection], mod: {Memcache.Application, []}]
   end
 
   def deps() do
     [
       {:connection, "~> 1.0.3"},
       {:poison, "~> 2.1 or ~> 3.0", optional: true},
-
       {:ex_doc, "~> 0.15.0", only: :dev},
       {:exprof, "~> 0.2.0", only: :dev},
       {:mcd, github: "EchoTeam/mcd", only: :dev},
@@ -38,15 +38,19 @@ defmodule Memcache.Mixfile do
   end
 
   defp package do
-    %{licenses: ["MIT"],
+    %{
+      licenses: ["MIT"],
       links: %{"Github" => "https://github.com/ananthakumaran/memcachex"},
-      maintainers: ["ananthakumaran@gmail.com"]}
+      maintainers: ["ananthakumaran@gmail.com"]
+    }
   end
 
   defp docs do
-    [source_url: "https://github.com/ananthakumaran/memcachex",
-     source_ref: "v#{@version}",
-     main: Memcache,
-     extras: ["README.md"]]
+    [
+      source_url: "https://github.com/ananthakumaran/memcachex",
+      source_ref: "v#{@version}",
+      main: Memcache,
+      extras: ["README.md"]
+    ]
   end
 end

--- a/profile.exs
+++ b/profile.exs
@@ -1,11 +1,11 @@
 import ExProf.Macro
 alias Memcache.Connection
 
-{ :ok, pid } = Connection.start_link([ hostname: "localhost" ])
-{ :ok } = Connection.execute(pid, :SET, ["hello", "world"])
+{:ok, pid} = Connection.start_link(hostname: "localhost")
+{:ok} = Connection.execute(pid, :SET, ["hello", "world"])
 
 profile do
   Enum.each(Range.new(0, 10000), fn _ ->
-    { :ok, "world" } = Connection.execute(pid, :GET, ["hello"])
+    {:ok, "world"} = Connection.execute(pid, :GET, ["hello"])
   end)
 end

--- a/test/memcache/connection_test.exs
+++ b/test/memcache/connection_test.exs
@@ -6,7 +6,7 @@ defmodule Memcache.ConnectionTest do
 
   doctest Connection
 
-  @cas_error { :error, "Key exists" }
+  @cas_error {:error, "Key exists"}
 
   setup do
     {:ok, _} = Toxiproxy.reset()
@@ -14,507 +14,507 @@ defmodule Memcache.ConnectionTest do
   end
 
   test "commands" do
-    { :ok, pid } = start_link([ port: 21211, hostname: "localhost" ])
-    cases = [
-             {:FLUSH, [], { :ok }},
-             {:GET, ["unknown"], { :error, "Key not found" }},
-             {:SET, ["hello", "world"], { :ok }},
-             {:GET, ["hello"], { :ok, "world" }},
-             {:SET, ["hello", ['w', 'o', "rl", 'd']], { :ok }},
-             {:GET, ["hello"], { :ok, "world" }},
-             {:SET, ["hello", "move on"], { :ok }},
-             {:SET, [<< 0x56 :: size(32) >>, << 0x56 :: size(32) >>], { :ok }},
-             {:GET, [<< 0x56 :: size(32) >>], { :ok, << 0x56 :: size(32) >>}},
-             {:GET, ["hello"], { :ok, "move on" }},
-             {:GETK, ["hello"], { :ok, "hello", "move on" }},
-             {:GETK, ["unknown"], { :error, "Key not found" }},
-             {:ADD, ["hello", "world"], { :error, "Key exists" }},
-             {:ADD, ["add", "world"], { :ok }},
-             {:DELETE, ["add"], { :ok }},
-             {:REPLACE, ["add", "world"], { :error, "Key not found" }},
-             {:ADD, ["add", "world"], { :ok }},
-             {:REPLACE, ["add", "world"], { :ok }},
-             {:DELETE, ["add"], { :ok }},
-             {:DELETE, ["hello"], { :ok }},
-             {:DELETE, ["unkown"], { :error, "Key not found" }},
-             {:INCREMENT, ["count", 1, 5], { :ok, 5 }},
-             {:INCREMENT, ["count", 1, 5], { :ok, 6 }},
-             {:INCREMENT, ["count", 5, 1], { :ok, 11 }},
-             {:DELETE, ["count"], { :ok }},
-             {:SET, ["hello", "world"], { :ok }},
-             {:INCREMENT, ["hello"], { :error, "Incr/Decr on non-numeric value"}},
-             {:DELETE, ["hello"], { :ok }},
-             {:DECREMENT, ["count", 1, 5], { :ok, 5 }},
-             {:DECREMENT, ["count", 1, 5], { :ok, 4 }},
-             {:DECREMENT, ["count", 6, 5], { :ok, 0 }},
-             {:DELETE, ["count"], { :ok }},
-             {:SET, ["hello", "world"], { :ok }},
-             {:DECREMENT, ["hello"], { :error, "Incr/Decr on non-numeric value"}},
-             {:DELETE, ["hello"], { :ok }},
-             {:INCREMENT, ["count", 6, 5, 0, 0xFFFFFFFF], { :error, "Key not found" }},
-             {:INCREMENT, ["count", 6, 5, 0, 0x05], { :ok, 5 }},
-             {:DELETE, ["count"], { :ok }},
-             {:NOOP, [], { :ok }},
-             {:APPEND, ["new", "hope"], { :error, "Item not stored" }},
-             {:SET, ["new", "new "], { :ok }},
-             {:APPEND, ["new", "hope"], { :ok }},
-             {:GET, ["new"], { :ok, "new hope"}},
-             {:DELETE, ["new"], { :ok }},
-             {:PREPEND, ["new", "hope"], { :error, "Item not stored"}},
-             {:SET, ["new", "hope"], { :ok }},
-             {:PREPEND, ["new", "new "], { :ok }},
-             {:GET, ["new"], { :ok, "new hope"}},
-             {:DELETE, ["new"], { :ok }},
-             {:SET, ["name", "ananth"], { :ok }},
-             {:FLUSH, [0xFFFF], { :ok }},
-             {:GET, ["name"], { :ok, "ananth" }},
-             {:FLUSH, [], { :ok }},
-             {:GET, ["name"], { :error, "Key not found" }}
-            ]
+    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
 
-    Enum.each(cases, fn ({ command, args, response }) ->
+    cases = [
+      {:FLUSH, [], {:ok}},
+      {:GET, ["unknown"], {:error, "Key not found"}},
+      {:SET, ["hello", "world"], {:ok}},
+      {:GET, ["hello"], {:ok, "world"}},
+      {:SET, ["hello", ['w', 'o', "rl", 'd']], {:ok}},
+      {:GET, ["hello"], {:ok, "world"}},
+      {:SET, ["hello", "move on"], {:ok}},
+      {:SET, [<<0x56::size(32)>>, <<0x56::size(32)>>], {:ok}},
+      {:GET, [<<0x56::size(32)>>], {:ok, <<0x56::size(32)>>}},
+      {:GET, ["hello"], {:ok, "move on"}},
+      {:GETK, ["hello"], {:ok, "hello", "move on"}},
+      {:GETK, ["unknown"], {:error, "Key not found"}},
+      {:ADD, ["hello", "world"], {:error, "Key exists"}},
+      {:ADD, ["add", "world"], {:ok}},
+      {:DELETE, ["add"], {:ok}},
+      {:REPLACE, ["add", "world"], {:error, "Key not found"}},
+      {:ADD, ["add", "world"], {:ok}},
+      {:REPLACE, ["add", "world"], {:ok}},
+      {:DELETE, ["add"], {:ok}},
+      {:DELETE, ["hello"], {:ok}},
+      {:DELETE, ["unkown"], {:error, "Key not found"}},
+      {:INCREMENT, ["count", 1, 5], {:ok, 5}},
+      {:INCREMENT, ["count", 1, 5], {:ok, 6}},
+      {:INCREMENT, ["count", 5, 1], {:ok, 11}},
+      {:DELETE, ["count"], {:ok}},
+      {:SET, ["hello", "world"], {:ok}},
+      {:INCREMENT, ["hello"], {:error, "Incr/Decr on non-numeric value"}},
+      {:DELETE, ["hello"], {:ok}},
+      {:DECREMENT, ["count", 1, 5], {:ok, 5}},
+      {:DECREMENT, ["count", 1, 5], {:ok, 4}},
+      {:DECREMENT, ["count", 6, 5], {:ok, 0}},
+      {:DELETE, ["count"], {:ok}},
+      {:SET, ["hello", "world"], {:ok}},
+      {:DECREMENT, ["hello"], {:error, "Incr/Decr on non-numeric value"}},
+      {:DELETE, ["hello"], {:ok}},
+      {:INCREMENT, ["count", 6, 5, 0, 0xFFFFFFFF], {:error, "Key not found"}},
+      {:INCREMENT, ["count", 6, 5, 0, 0x05], {:ok, 5}},
+      {:DELETE, ["count"], {:ok}},
+      {:NOOP, [], {:ok}},
+      {:APPEND, ["new", "hope"], {:error, "Item not stored"}},
+      {:SET, ["new", "new "], {:ok}},
+      {:APPEND, ["new", "hope"], {:ok}},
+      {:GET, ["new"], {:ok, "new hope"}},
+      {:DELETE, ["new"], {:ok}},
+      {:PREPEND, ["new", "hope"], {:error, "Item not stored"}},
+      {:SET, ["new", "hope"], {:ok}},
+      {:PREPEND, ["new", "new "], {:ok}},
+      {:GET, ["new"], {:ok, "new hope"}},
+      {:DELETE, ["new"], {:ok}},
+      {:SET, ["name", "ananth"], {:ok}},
+      {:FLUSH, [0xFFFF], {:ok}},
+      {:GET, ["name"], {:ok, "ananth"}},
+      {:FLUSH, [], {:ok}},
+      {:GET, ["name"], {:error, "Key not found"}}
+    ]
+
+    Enum.each(cases, fn {command, args, response} ->
       assert(execute(pid, command, args) == response)
     end)
 
-    { :ok } = close(pid)
+    {:ok} = close(pid)
   end
 
   test "cas commands" do
-    { :ok, pid } = start_link([ port: 21211, hostname: "localhost" ])
+    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
+
     cases = [
-      {:FLUSH, [], [], { :ok }},
-      {:GET, ["unknown"], [cas: true], { :error, "Key not found" }},
-      {:SET, ["hello", "world"], [cas: true], { :ok, :cas }},
-      {:SET, ["hello", "world", :cas], [cas: true], { :ok, :cas }},
-      {:SET, ["hello", "another"], [], { :ok }},
+      {:FLUSH, [], [], {:ok}},
+      {:GET, ["unknown"], [cas: true], {:error, "Key not found"}},
+      {:SET, ["hello", "world"], [cas: true], {:ok, :cas}},
+      {:SET, ["hello", "world", :cas], [cas: true], {:ok, :cas}},
+      {:SET, ["hello", "another"], [], {:ok}},
       {:SET, ["hello", "world", :cas], [cas: true], @cas_error},
-      {:GET, ["hello"], [cas: true], { :ok, "another", :cas }},
-      {:SET, ["hello", "world", :cas], [cas: true], { :ok, :cas }},
-      {:SET, ["hello", "move on", :cas], [], { :ok }},
-      {:GET, ["hello"], [], { :ok, "move on" }},
-      {:ADD, ["add", "world"], [cas: true], { :ok, :cas }},
-      {:DELETE, ["add", :cas], [], { :ok }},
-      {:ADD, ["add", "world"], [], { :ok }},
+      {:GET, ["hello"], [cas: true], {:ok, "another", :cas}},
+      {:SET, ["hello", "world", :cas], [cas: true], {:ok, :cas}},
+      {:SET, ["hello", "move on", :cas], [], {:ok}},
+      {:GET, ["hello"], [], {:ok, "move on"}},
+      {:ADD, ["add", "world"], [cas: true], {:ok, :cas}},
+      {:DELETE, ["add", :cas], [], {:ok}},
+      {:ADD, ["add", "world"], [], {:ok}},
       {:DELETE, ["add", :cas], [], @cas_error},
-      {:REPLACE, ["add", "world"], [cas: true], { :ok, :cas }},
-      {:REPLACE, ["add", "world", :cas], [], { :ok }},
+      {:REPLACE, ["add", "world"], [cas: true], {:ok, :cas}},
+      {:REPLACE, ["add", "world", :cas], [], {:ok}},
       {:REPLACE, ["add", "world", :cas], [], @cas_error},
       {:DELETE, ["add", :cas], [], @cas_error},
-      {:GET, ["add"], [cas: true], { :ok, "world", :cas }},
-      {:DELETE, ["add", :cas], [], { :ok }},
-      {:INCREMENT, ["count", 1, 5], [cas: true], { :ok, 5, :cas }},
-      {:INCREMENT, ["count", 1, 5], [], { :ok, 6 }},
+      {:GET, ["add"], [cas: true], {:ok, "world", :cas}},
+      {:DELETE, ["add", :cas], [], {:ok}},
+      {:INCREMENT, ["count", 1, 5], [cas: true], {:ok, 5, :cas}},
+      {:INCREMENT, ["count", 1, 5], [], {:ok, 6}},
       {:INCREMENT, ["count", 5, 1, :cas], [], @cas_error},
-      {:DELETE, ["count"], [], { :ok }},
-      {:DECREMENT, ["count", 1, 5], [cas: true], { :ok, 5, :cas }},
-      {:DECREMENT, ["count", 1, 5, :cas], [], { :ok, 4 }},
+      {:DELETE, ["count"], [], {:ok}},
+      {:DECREMENT, ["count", 1, 5], [cas: true], {:ok, 5, :cas}},
+      {:DECREMENT, ["count", 1, 5, :cas], [], {:ok, 4}},
       {:DECREMENT, ["count", 6, 5, :cas], [], @cas_error},
-      {:DELETE, ["count"], [], { :ok }},
-      {:SET, ["new", "new "], [cas: true], { :ok, :cas }},
-      {:APPEND, ["new", "hope", :cas], [], { :ok }},
+      {:DELETE, ["count"], [], {:ok}},
+      {:SET, ["new", "new "], [cas: true], {:ok, :cas}},
+      {:APPEND, ["new", "hope", :cas], [], {:ok}},
       {:APPEND, ["new", "hope", :cas], [], @cas_error},
-      {:APPEND, ["new", "hope"], [cas: true], { :ok, :cas }},
-      {:GET, ["new"], [], { :ok, "new hopehope"}},
-      {:SET, ["new", "hope"], [cas: true], { :ok, :cas }},
-      {:PREPEND, ["new", "new ", :cas], [], { :ok }},
+      {:APPEND, ["new", "hope"], [cas: true], {:ok, :cas}},
+      {:GET, ["new"], [], {:ok, "new hopehope"}},
+      {:SET, ["new", "hope"], [cas: true], {:ok, :cas}},
+      {:PREPEND, ["new", "new ", :cas], [], {:ok}},
       {:PREPEND, ["new", "new ", :cas], [], @cas_error},
-      {:PREPEND, ["new", "new "], [cas: true], { :ok, :cas }},
-      {:FLUSH, [], [], { :ok }},
+      {:PREPEND, ["new", "new "], [cas: true], {:ok, :cas}},
+      {:FLUSH, [], [], {:ok}}
     ]
 
-    Enum.reduce(cases, nil, fn ({ command, args, opts, response }, cas) ->
-      embed_cas = fn (:cas) -> cas
-        (rest) -> rest
+    Enum.reduce(cases, nil, fn {command, args, opts, response}, cas ->
+      embed_cas = fn
+        :cas -> cas
+        rest -> rest
       end
+
       args = Enum.map(args, embed_cas)
+
       case response do
-        { :ok, :cas } ->
-          assert { :ok, cas } = execute(pid, command, args, opts)
+        {:ok, :cas} ->
+          assert {:ok, cas} = execute(pid, command, args, opts)
           cas
-        { :ok, value, :cas } ->
-          assert { :ok, ^value, cas } = execute(pid, command, args, opts)
+
+        {:ok, value, :cas} ->
+          assert {:ok, ^value, cas} = execute(pid, command, args, opts)
           cas
+
         rest ->
           assert rest == execute(pid, command, args, opts)
           cas
       end
     end)
 
-    { :ok } = close(pid)
+    {:ok} = close(pid)
   end
 
-
   test "quiet commands" do
-    { :ok, pid } = start_link([ port: 21211, hostname: "localhost" ])
-    { :ok } = execute(pid, :FLUSH, [])
-    { :ok } = execute(pid, :SET, ["new", "hope"])
+    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
+    {:ok} = execute(pid, :FLUSH, [])
+    {:ok} = execute(pid, :SET, ["new", "hope"])
+
     cases = [
-             { [{:GETQ, ["hello"]},
-                {:GETQ, ["hello"]}],
-               { :ok, [{ :error, "Key not found" },
-                       { :error, "Key not found" }] }},
+      {[{:GETQ, ["hello"]}, {:GETQ, ["hello"]}],
+       {:ok, [{:error, "Key not found"}, {:error, "Key not found"}]}},
+      {[{:GETQ, ["new"]}, {:GETQ, ["new"]}], {:ok, [{:ok, "hope"}, {:ok, "hope"}]}},
+      {[{:GETKQ, ["new"]}, {:GETKQ, ["unknown"]}],
+       {:ok, [{:ok, "new", "hope"}, {:error, "Key not found"}]}},
+      {[
+         {:SETQ, ["hello", "WORLD"]},
+         {:GETQ, ["hello"]},
+         {:SETQ, ["hello", "world"]},
+         {:GETQ, ["hello"]},
+         {:DELETEQ, ["hello"]},
+         {:GETQ, ["hello"]}
+       ],
+       {:ok, [{:ok}, {:ok, "WORLD"}, {:ok}, {:ok, "world"}, {:ok}, {:error, "Key not found"}]}},
+      {[
+         {:SETQ, ["hello", "WORLD"]},
+         {:FLUSHQ, []},
+         {:GETQ, ["hello"]},
+         {:SETQ, ["hello", "world"]},
+         {:FLUSHQ, [0xFFFF]},
+         {:GETQ, ["hello"]},
+         {:FLUSHQ, []},
+         {:GETQ, ["hello"]}
+       ],
+       {:ok,
+        [
+          {:ok},
+          {:ok},
+          {:error, "Key not found"},
+          {:ok},
+          {:ok},
+          {:ok, "world"},
+          {:ok},
+          {:error, "Key not found"}
+        ]}},
+      {[
+         {:SETQ, ["hello", "world"]},
+         {:ADDQ, ["hello", "world"]},
+         {:ADDQ, ["add", "world"]},
+         {:GETQ, ["add"]},
+         {:DELETEQ, ["add"]},
+         {:DELETEQ, ["unknown"]}
+       ],
+       {:ok,
+        [{:ok}, {:error, "Key exists"}, {:ok}, {:ok, "world"}, {:ok}, {:error, "Key not found"}]}},
+      {[
+         {:INCREMENTQ, ["count", 1, 5]},
+         {:INCREMENTQ, ["count", 1, 5]},
+         {:GETQ, ["count"]},
+         {:INCREMENTQ, ["count", 5]},
+         {:GETQ, ["count"]},
+         {:DELETEQ, ["count"]},
+         {:SETQ, ["hello", "world"]},
+         {:INCREMENTQ, ["hello", 1]},
+         {:DELETEQ, ["hello"]}
+       ],
+       {:ok,
+        [
+          {:ok},
+          {:ok},
+          {:ok, "6"},
+          {:ok},
+          {:ok, "11"},
+          {:ok},
+          {:ok},
+          {:error, "Incr/Decr on non-numeric value"},
+          {:ok}
+        ]}},
+      {[
+         {:DECREMENTQ, ["count", 1, 5]},
+         {:DECREMENTQ, ["count", 1, 5]},
+         {:GETQ, ["count"]},
+         {:DECREMENTQ, ["count", 5]},
+         {:GETQ, ["count"]},
+         {:DELETEQ, ["count"]},
+         {:SETQ, ["hello", "world"]},
+         {:DECREMENTQ, ["hello", 1]},
+         {:DELETEQ, ["hello"]}
+       ],
+       {:ok,
+        [
+          {:ok},
+          {:ok},
+          {:ok, "4"},
+          {:ok},
+          {:ok, "0"},
+          {:ok},
+          {:ok},
+          {:error, "Incr/Decr on non-numeric value"},
+          {:ok}
+        ]}},
+      {[
+         {:REPLACEQ, ["add", "world"]},
+         {:ADDQ, ["add", "world"]},
+         {:REPLACEQ, ["add", "new"]},
+         {:GETQ, ["add"]},
+         {:DELETEQ, ["add"]}
+       ], {:ok, [{:error, "Key not found"}, {:ok}, {:ok}, {:ok, "new"}, {:ok}]}},
+      {[
+         {:SETQ, ["new", "new "]},
+         {:DELETEQ, ["new"]},
+         {:APPENDQ, ["new", "hope"]},
+         {:SETQ, ["new", "new "]},
+         {:APPENDQ, ["new", "hope"]},
+         {:GETQ, ["new"]},
+         {:DELETEQ, ["new"]},
+         {:PREPENDQ, ["new", "hope"]},
+         {:SETQ, ["new", "hope"]},
+         {:PREPENDQ, ["new", "new "]},
+         {:GETQ, ["new"]},
+         {:DELETEQ, ["new"]}
+       ],
+       {:ok,
+        [
+          {:ok},
+          {:ok},
+          {:error, "Item not stored"},
+          {:ok},
+          {:ok},
+          {:ok, "new hope"},
+          {:ok},
+          {:error, "Item not stored"},
+          {:ok},
+          {:ok},
+          {:ok, "new hope"},
+          {:ok}
+        ]}}
+    ]
 
-             { [{:GETQ, ["new"]},
-                {:GETQ, ["new"]}],
-               { :ok, [{ :ok, "hope" },
-                       { :ok, "hope" }] }},
-
-             { [{:GETKQ, ["new"]},
-                {:GETKQ, ["unknown"]}],
-               { :ok, [{ :ok, "new", "hope" },
-                       { :error, "Key not found" }] }},
-
-             { [{:SETQ, ["hello", "WORLD"]},
-                {:GETQ, ["hello"]},
-                {:SETQ, ["hello", "world"]},
-                {:GETQ, ["hello"]},
-                {:DELETEQ, ["hello"]},
-                {:GETQ, ["hello"]}],
-               { :ok, [{ :ok },
-                       { :ok, "WORLD" },
-                       { :ok },
-                       { :ok, "world" },
-                       { :ok },
-                       { :error, "Key not found" }] }},
-
-             { [{:SETQ, ["hello", "WORLD"]},
-                {:FLUSHQ, []},
-                {:GETQ, ["hello"]},
-                {:SETQ, ["hello", "world"]},
-                {:FLUSHQ, [0xFFFF]},
-                {:GETQ, ["hello"]},
-                {:FLUSHQ, []},
-                {:GETQ, ["hello"]}],
-               { :ok, [{ :ok },
-                       { :ok },
-                       { :error, "Key not found" },
-                       { :ok },
-                       { :ok },
-                       { :ok, "world" },
-                       { :ok },
-                       { :error, "Key not found" }] }},
-
-             { [{:SETQ, ["hello", "world"]},
-                {:ADDQ, ["hello", "world"]},
-                {:ADDQ, ["add", "world"]},
-                {:GETQ, ["add"]},
-                {:DELETEQ, ["add"]},
-                {:DELETEQ, ["unknown"]}],
-               { :ok, [{ :ok },
-                       { :error, "Key exists" },
-                       { :ok },
-                       { :ok, "world" },
-                       { :ok },
-                       { :error, "Key not found" }] }},
-
-               { [{:INCREMENTQ, ["count", 1, 5]},
-                  {:INCREMENTQ, ["count", 1, 5]},
-                  {:GETQ, ["count"]},
-                  {:INCREMENTQ, ["count", 5]},
-                  {:GETQ, ["count"]},
-                  {:DELETEQ, ["count"]},
-                  {:SETQ, ["hello", "world"]},
-                  {:INCREMENTQ, ["hello", 1]},
-                  {:DELETEQ, ["hello"]},],
-               { :ok, [{ :ok },
-                       { :ok },
-                       { :ok, "6" },
-                       { :ok },
-                       { :ok , "11"},
-                       { :ok },
-                       { :ok },
-                       { :error, "Incr/Decr on non-numeric value"},
-                       { :ok }]}},
-
-               { [{:DECREMENTQ, ["count", 1, 5]},
-                  {:DECREMENTQ, ["count", 1, 5]},
-                  {:GETQ, ["count"]},
-                  {:DECREMENTQ, ["count", 5]},
-                  {:GETQ, ["count"]},
-                  {:DELETEQ, ["count"]},
-                  {:SETQ, ["hello", "world"]},
-                  {:DECREMENTQ, ["hello", 1]},
-                  {:DELETEQ, ["hello"]},],
-               { :ok, [{ :ok },
-                       { :ok },
-                       { :ok, "4" },
-                       { :ok },
-                       { :ok , "0"},
-                       { :ok },
-                       { :ok },
-                       { :error, "Incr/Decr on non-numeric value"},
-                       { :ok }]}},
-
-             { [{:REPLACEQ, ["add", "world"]},
-                {:ADDQ, ["add", "world"]},
-                {:REPLACEQ, ["add", "new"]},
-                {:GETQ, ["add"]},
-                {:DELETEQ, ["add"]}],
-               { :ok, [{ :error, "Key not found" },
-                       { :ok },
-                       { :ok },
-                       { :ok, "new" },
-                       { :ok }]}},
-
-             { [{:SETQ, ["new", "new "]},
-                {:DELETEQ, ["new"]},
-                {:APPENDQ, ["new", "hope"]},
-                {:SETQ, ["new", "new "]},
-                {:APPENDQ, ["new", "hope"]},
-                {:GETQ, ["new"]},
-                {:DELETEQ, ["new"]},
-                {:PREPENDQ, ["new", "hope"]},
-                {:SETQ, ["new", "hope"]},
-                {:PREPENDQ, ["new", "new "]},
-                {:GETQ, ["new"]},
-                {:DELETEQ, ["new"]}],
-               { :ok, [{ :ok },
-                       { :ok },
-                       { :error, "Item not stored" },
-                       { :ok },
-                       { :ok },
-                       { :ok, "new hope"},
-                       { :ok },
-                       { :error, "Item not stored"},
-                       { :ok },
-                       { :ok },
-                       { :ok, "new hope"},
-                       { :ok }]}}
-            ]
-
-    Enum.each(cases, fn ({ commands, response }) ->
+    Enum.each(cases, fn {commands, response} ->
       assert(execute_quiet(pid, commands) == response)
     end)
 
-    { :ok } = close(pid)
+    {:ok} = close(pid)
   end
 
   test "quiet cas commands" do
-    { :ok, pid } = start_link([ port: 21211, hostname: "localhost" ])
-    { :ok } = execute(pid, :FLUSH, [])
-    { :ok } = execute(pid, :SET, ["new", "hope"])
+    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
+    {:ok} = execute(pid, :FLUSH, [])
+    {:ok} = execute(pid, :SET, ["new", "hope"])
 
-    assert { :ok, [{ :ok, "hope", cas},
-                   { :ok, "hope", cas}] } =
-      execute_quiet(pid, [{:GETQ, ["new"], [cas: true]},
-                          {:GETQ, ["new"], [cas: true]}])
+    assert {:ok, [{:ok, "hope", cas}, {:ok, "hope", cas}]} =
+             execute_quiet(pid, [{:GETQ, ["new"], [cas: true]}, {:GETQ, ["new"], [cas: true]}])
 
+    assert {:ok, [{:ok, cas}, @cas_error]} =
+             execute_quiet(pid, [
+               {:SET, ["new", "hope", cas], [cas: true]},
+               {:SETQ, ["new", "hope", cas]}
+             ])
 
-    assert { :ok, [{ :ok, cas},
-                   @cas_error] } =
-      execute_quiet(pid, [{:SET, ["new", "hope", cas], [cas: true]},
-                          {:SETQ, ["new", "hope", cas]}])
+    assert {:ok, [@cas_error, {:ok}, {:error, "Key not found"}, {:ok}, {:ok, "hope", cas}]} =
+             execute_quiet(pid, [
+               {:DELETEQ, ["new", 1492]},
+               {:DELETEQ, ["new", cas]},
+               {:GETQ, ["new"]},
+               {:SETQ, ["new", "hope"]},
+               {:GETQ, ["new"], [cas: true]}
+             ])
 
+    assert {:ok, [{:ok}, {:error, "Key exists"}, {:ok, _cas}, {:ok}]} =
+             execute_quiet(pid, [
+               {:SETQ, ["new", "world", cas]},
+               {:ADDQ, ["new", "world"]},
+               {:ADD, ["add", "world"], [cas: true]},
+               {:DELETEQ, ["add"]}
+             ])
 
-    assert { :ok, [@cas_error,
-                   { :ok },
-                   { :error, "Key not found" },
-                   { :ok },
-                   {:ok, "hope", cas}]} =
-      execute_quiet(pid, [{:DELETEQ, ["new", 1492]},
-                          {:DELETEQ, ["new", cas]},
-                          {:GETQ, ["new"]},
-                          {:SETQ, ["new", "hope"]},
-                          {:GETQ, ["new"], [cas: true]}])
+    assert {:ok, [{:ok}, {:ok, 6, cas}]} =
+             execute_quiet(pid, [
+               {:INCREMENTQ, ["count", 1, 5]},
+               {:INCREMENT, ["count", 1, 5], [cas: true]}
+             ])
 
+    assert {:ok, [{:ok}, {:ok, "7"}, @cas_error, {:ok, "7"}, {:ok}, {:ok, "12"}, {:ok}]} =
+             execute_quiet(pid, [
+               {:INCREMENTQ, ["count", 1, 5, cas]},
+               {:GETQ, ["count"]},
+               {:INCREMENTQ, ["count", 1, 5, cas]},
+               {:GETQ, ["count"]},
+               {:INCREMENTQ, ["count", 5]},
+               {:GETQ, ["count"]},
+               {:DELETEQ, ["count"]}
+             ])
 
-    assert { :ok, [{ :ok },
-                   { :error, "Key exists" },
-                   { :ok, _cas},
-                   { :ok }] } =
-      execute_quiet(pid, [{:SETQ, ["new", "world", cas]},
-                          {:ADDQ, ["new", "world"]},
-                          {:ADD, ["add", "world"], [cas: true]},
-                          {:DELETEQ, ["add"]}])
+    assert {:ok, [{:ok}, {:ok, 4, cas}]} =
+             execute_quiet(pid, [
+               {:DECREMENTQ, ["count", 1, 5]},
+               {:DECREMENT, ["count", 1, 5], [cas: true]}
+             ])
 
+    assert {:ok, [{:ok}, {:ok, "3"}, @cas_error, {:ok, "3"}, {:ok}, {:ok, "0"}, {:ok}]} ==
+             execute_quiet(pid, [
+               {:DECREMENTQ, ["count", 1, 5, cas]},
+               {:GETQ, ["count"]},
+               {:DECREMENTQ, ["count", 1, 5, cas]},
+               {:GETQ, ["count"]},
+               {:DECREMENTQ, ["count", 5]},
+               {:GETQ, ["count"]},
+               {:DELETEQ, ["count"]}
+             ])
 
-    assert { :ok, [{ :ok },
-                   { :ok, 6, cas}]} =
-      execute_quiet(pid, [{:INCREMENTQ, ["count", 1, 5]},
-                          {:INCREMENT, ["count", 1, 5], [cas: true]}])
+    assert {:ok, [{:error, "Key not found"}, {:ok}, {:ok, cas}]} =
+             execute_quiet(pid, [
+               {:REPLACEQ, ["add", "world"]},
+               {:ADDQ, ["add", "world"]},
+               {:REPLACE, ["add", "world"], [cas: true]}
+             ])
 
-    assert { :ok, [{ :ok },
-                   { :ok, "7" },
-                   @cas_error,
-                   { :ok, "7" },
-                   { :ok },
-                   { :ok, "12" },
-                   { :ok }]} =
-      execute_quiet(pid, [{:INCREMENTQ, ["count", 1, 5, cas]},
-                          {:GETQ, ["count"]},
-                          {:INCREMENTQ, ["count", 1, 5, cas]},
-                          {:GETQ, ["count"]},
-                          {:INCREMENTQ, ["count", 5]},
-                          {:GETQ, ["count"]},
-                          {:DELETEQ, ["count"]}])
+    assert {:ok, [{:ok}, {:ok, "world"}, @cas_error, {:ok, "world"}, {:ok}]} ==
+             execute_quiet(pid, [
+               {:REPLACEQ, ["add", "world", cas]},
+               {:GETQ, ["add"]},
+               {:REPLACEQ, ["add", "new", cas]},
+               {:GETQ, ["add"]},
+               {:DELETEQ, ["add"]}
+             ])
 
-    assert { :ok, [{ :ok },
-                   { :ok, 4, cas}]} =
-      execute_quiet(pid, [{:DECREMENTQ, ["count", 1, 5]},
-                          {:DECREMENT, ["count", 1, 5], [cas: true]}])
+    assert {:ok, [{:ok}, {:ok, casa}, {:ok}, {:ok, casp}]} =
+             execute_quiet(pid, [
+               {:SETQ, ["a", "new"]},
+               {:APPEND, ["a", " "], [cas: true]},
+               {:SETQ, ["p", "hope"]},
+               {:PREPEND, ["p", " "], [cas: true]}
+             ])
 
+    assert {:ok,
+            [
+              {:ok},
+              {:ok, "new hope"},
+              @cas_error,
+              {:ok, "new hope"},
+              {:ok},
+              {:ok, "new hope"},
+              @cas_error,
+              {:ok, "new hope"},
+              {:ok},
+              {:ok}
+            ]} ==
+             execute_quiet(pid, [
+               {:APPENDQ, ["a", "hope", casa]},
+               {:GETQ, ["a"]},
+               {:APPENDQ, ["a", "hope", casa]},
+               {:GETQ, ["a"]},
+               {:PREPENDQ, ["p", "new", casp]},
+               {:GETQ, ["p"]},
+               {:PREPENDQ, ["p", "new", casp]},
+               {:GETQ, ["p"]},
+               {:DELETEQ, ["a"]},
+               {:DELETEQ, ["p"]}
+             ])
 
-    assert { :ok, [{ :ok },
-                   { :ok, "3" },
-                   @cas_error,
-                   { :ok, "3" },
-                   { :ok },
-                   { :ok , "0"},
-                   { :ok }]} ==
-      execute_quiet(pid, [{:DECREMENTQ, ["count", 1, 5, cas]},
-                          {:GETQ, ["count"]},
-                          {:DECREMENTQ, ["count", 1, 5, cas]},
-                          {:GETQ, ["count"]},
-                          {:DECREMENTQ, ["count", 5]},
-                          {:GETQ, ["count"]},
-                          {:DELETEQ, ["count"]}])
-
-    assert { :ok, [{ :error, "Key not found" },
-                   { :ok },
-                   { :ok, cas}]} =
-      execute_quiet(pid, [{:REPLACEQ, ["add", "world"]},
-                          {:ADDQ, ["add", "world"]},
-                          {:REPLACE, ["add", "world"], [cas: true]}])
-
-
-    assert { :ok, [{ :ok },
-                   { :ok, "world" },
-                   @cas_error,
-                   { :ok, "world" },
-                   { :ok }]} ==
-      execute_quiet(pid, [{:REPLACEQ, ["add", "world", cas]},
-                          {:GETQ, ["add"]},
-                          {:REPLACEQ, ["add", "new", cas]},
-                          {:GETQ, ["add"]},
-                          {:DELETEQ, ["add"]}])
-
-    assert { :ok, [{ :ok },
-                   { :ok, casa},
-                   { :ok },
-                   { :ok, casp}]} =
-      execute_quiet(pid, [{:SETQ, ["a", "new"]},
-                          {:APPEND, ["a", " "], [cas: true]},
-                          {:SETQ, ["p", "hope"]},
-                          {:PREPEND, ["p", " "], [cas: true]}])
-
-    assert { :ok, [{ :ok },
-                   { :ok, "new hope"},
-                   @cas_error,
-                   { :ok, "new hope"},
-                   { :ok },
-                   { :ok, "new hope"},
-                   @cas_error,
-                   { :ok, "new hope"},
-                   { :ok },
-                   { :ok }]} ==
-      execute_quiet(pid, [{:APPENDQ, ["a", "hope", casa]},
-                          {:GETQ, ["a"]},
-                          {:APPENDQ, ["a", "hope", casa]},
-                          {:GETQ, ["a"]},
-                          {:PREPENDQ, ["p", "new", casp]},
-                          {:GETQ, ["p"]},
-                          {:PREPENDQ, ["p", "new", casp]},
-                          {:GETQ, ["p"]},
-                          {:DELETEQ, ["a"]},
-                          {:DELETEQ, ["p"]}])
-
-    { :ok } = close(pid)
+    {:ok} = close(pid)
   end
 
-
   test "misc commands" do
-    { :ok, pid } = start_link([ port: 21211, hostname: "localhost" ])
-    { :ok, _stat } = execute(pid, :STAT, [])
-    { :ok, _stat } = execute(pid, :STAT, ["items"])
-    { :ok, _stat } = execute(pid, :STAT, ["slabs"])
-    { :ok, _stat } = execute(pid, :STAT, ["settings"])
-    { :ok, version } = execute(pid, :VERSION, [])
-    assert  version =~ ~r/\d+\.\d+\.\d+/
-    { :ok } = close(pid)
+    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
+    {:ok, _stat} = execute(pid, :STAT, [])
+    {:ok, _stat} = execute(pid, :STAT, ["items"])
+    {:ok, _stat} = execute(pid, :STAT, ["slabs"])
+    {:ok, _stat} = execute(pid, :STAT, ["settings"])
+    {:ok, version} = execute(pid, :VERSION, [])
+    assert version =~ ~r/\d+\.\d+\.\d+/
+    {:ok} = close(pid)
   end
 
   test "named process" do
-    { :ok, pid } = start_link([ port: 21211, hostname: "localhost" ], [name: :memcachex])
-    { :ok } = execute(:memcachex, :SET, ["hello", "world"])
-    { :ok, "world" } = execute(:memcachex, :GET, ["hello"])
-    { :ok } = close(pid)
+    {:ok, pid} = start_link([port: 21211, hostname: "localhost"], name: :memcachex)
+    {:ok} = execute(:memcachex, :SET, ["hello", "world"])
+    {:ok, "world"} = execute(:memcachex, :GET, ["hello"])
+    {:ok} = close(pid)
   end
 
   test "continue if auth is not supported" do
     assert capture_log(fn ->
-      { :ok, pid } = start_link([port: 21211, auth: {:plain, "user", "pass"}])
-      :timer.sleep(100)
-      { :ok } = close(pid)
-    end) =~ "Authentication not required"
+             {:ok, pid} = start_link(port: 21211, auth: {:plain, "user", "pass"})
+             :timer.sleep(100)
+             {:ok} = close(pid)
+           end) =~ "Authentication not required"
   end
 
   test "reconnects automatically" do
-    { :ok, pid } = start_link([port: 21211])
+    {:ok, pid} = start_link(port: 21211)
     down("memcache")
     :timer.sleep(100)
     up("memcache")
     :timer.sleep(1000)
-    { :ok } = execute(pid, :SET, ["hello", "world"])
-    { :ok, "world" } = execute(pid, :GET, ["hello"])
-    { :ok } = close(pid)
+    {:ok} = execute(pid, :SET, ["hello", "world"])
+    {:ok, "world"} = execute(pid, :GET, ["hello"])
+    {:ok} = close(pid)
   end
 
   test "always responds back to client" do
-    { :ok, pid } = start_link([port: 21211])
+    {:ok, pid} = start_link(port: 21211)
     assert {:ok} = execute(pid, :SET, ["hello", "world"])
-    pids = start_hammering(fn ->
-      assert_value_or_error({:ok}, execute(pid, :SET, ["hello", "world"]))
-      assert_value_or_error({:ok, "world"}, execute(pid, :GET, ["hello"]))
-    end, 8)
+
+    pids =
+      start_hammering(
+        fn ->
+          assert_value_or_error({:ok}, execute(pid, :SET, ["hello", "world"]))
+          assert_value_or_error({:ok, "world"}, execute(pid, :GET, ["hello"]))
+        end,
+        8
+      )
+
     down("memcache")
     :timer.sleep(100)
     up("memcache")
     :timer.sleep(1000)
     stop_hammering(pids)
-    { :ok } = close(pid)
+    {:ok} = close(pid)
   end
 
   defp assert_value_or_error(value, value), do: true
   defp assert_value_or_error(_value, {:error, _}), do: true
+
   defp assert_value_or_error(value, actual) do
     flunk("Expected #{inspect(value)} or {:error, closed}\n but got #{inspect(actual)}")
   end
 
   @tag :authentication
   test "fail on unsupported auth type" do
-    assert_exit(fn ->
-      { :ok, pid } = start_link([port: 9494, auth: {:ldap, "user@example.com", "pass"}])
-      :timer.sleep(100)
-      { :ok } = close(pid)
-    end, ~r/only supports :plain/)
+    assert_exit(
+      fn ->
+        {:ok, pid} = start_link(port: 9494, auth: {:ldap, "user@example.com", "pass"})
+        :timer.sleep(100)
+        {:ok} = close(pid)
+      end,
+      ~r/only supports :plain/
+    )
   end
 
   @tag :authentication
   test "plain auth" do
-    { :ok, pid } = start_link([port: 9494, auth: {:plain, "user@example.com", "pass"}])
-    { :ok } = execute(pid, :NOOP, [])
-    { :ok } = close(pid)
+    {:ok, pid} = start_link(port: 9494, auth: {:plain, "user@example.com", "pass"})
+    {:ok} = execute(pid, :NOOP, [])
+    {:ok} = close(pid)
   end
 
   @tag :authentication
   test "reconnects automatically with auth" do
-    { :ok, pid } = start_link([port: 9494, auth: {:plain, "user@example.com", "pass"}])
+    {:ok, pid} = start_link(port: 9494, auth: {:plain, "user@example.com", "pass"})
     down("memcache_sasl")
     :timer.sleep(100)
     up("memcache_sasl")
     :timer.sleep(1000)
-    { :ok } = execute(pid, :SET, ["hello", "world"])
-    { :ok, "world" } = execute(pid, :GET, ["hello"])
-    { :ok } = close(pid)
+    {:ok} = execute(pid, :SET, ["hello", "world"])
+    {:ok, "world"} = execute(pid, :GET, ["hello"])
+    {:ok} = close(pid)
   end
-
 
   @tag :authentication
   test "invalid password" do
-    assert_exit(fn ->
-      { :ok, pid } = start_link([port: 9494, auth: {:plain, "user@example.com", "ps"}])
-      :timer.sleep(100)
-      { :ok } = close(pid)
-    end, ~r/auth.*not.*successful/i)
+    assert_exit(
+      fn ->
+        {:ok, pid} = start_link(port: 9494, auth: {:plain, "user@example.com", "ps"})
+        :timer.sleep(100)
+        {:ok} = close(pid)
+      end,
+      ~r/auth.*not.*successful/i
+    )
   end
 end

--- a/test/memcache/registry_test.exs
+++ b/test/memcache/registry_test.exs
@@ -3,17 +3,20 @@ defmodule Memcache.RegistryTest do
   alias Memcache.Registry
 
   test "clears data when the process exits" do
-    Registry.start_link
+    Registry.start_link()
 
-    pid = spawn_link(fn ->
-      receive do
-        :exit -> :ok
-      end
-    end)
+    pid =
+      spawn_link(fn ->
+        receive do
+          :exit -> :ok
+        end
+      end)
+
     assert Registry.associate(pid, :ok) == :ok
     assert Registry.lookup(pid) == :ok
     send(pid, :exit)
     Process.sleep(50)
+
     assert_raise(ArgumentError, fn ->
       Registry.lookup(pid)
     end)

--- a/test/memcache_test.exs
+++ b/test/memcache_test.exs
@@ -10,126 +10,138 @@ defmodule MemcacheTest do
   doctest Memcache
 
   def append_prepend(pid) do
-    assert { :ok } = Memcache.flush(pid)
-    assert { :ok } == Memcache.set(pid, "hello", "world")
-    assert { :ok } == Memcache.append(pid, "hello", "!")
-    assert { :ok, "world!" } == Memcache.get(pid, "hello")
-    assert { :ok } == Memcache.prepend(pid, "hello", "!")
-    assert { :ok, "!world!" } == Memcache.get(pid, "hello")
-    cas_error = { :error, "Key exists" }
+    assert {:ok} = Memcache.flush(pid)
+    assert {:ok} == Memcache.set(pid, "hello", "world")
+    assert {:ok} == Memcache.append(pid, "hello", "!")
+    assert {:ok, "world!"} == Memcache.get(pid, "hello")
+    assert {:ok} == Memcache.prepend(pid, "hello", "!")
+    assert {:ok, "!world!"} == Memcache.get(pid, "hello")
+    cas_error = {:error, "Key exists"}
 
-    assert { :ok, cas } = Memcache.set(pid, "new", "new ", [cas: true])
-    assert { :ok } == Memcache.append_cas(pid, "new", "hope", cas)
+    assert {:ok, cas} = Memcache.set(pid, "new", "new ", cas: true)
+    assert {:ok} == Memcache.append_cas(pid, "new", "hope", cas)
     assert cas_error == Memcache.append_cas(pid, "new", "hope", cas)
-    assert { :ok, _cas } = Memcache.append(pid, "new", "hope", [cas: true])
-    assert { :ok, "new hopehope"} == Memcache.get(pid, "new")
-    assert { :ok, cas } = Memcache.set(pid, "new", "hope", [cas: true])
-    assert { :ok } == Memcache.prepend_cas(pid, "new", "new ", cas)
+    assert {:ok, _cas} = Memcache.append(pid, "new", "hope", cas: true)
+    assert {:ok, "new hopehope"} == Memcache.get(pid, "new")
+    assert {:ok, cas} = Memcache.set(pid, "new", "hope", cas: true)
+    assert {:ok} == Memcache.prepend_cas(pid, "new", "new ", cas)
     assert cas_error == Memcache.prepend_cas(pid, "new", "new ", cas)
-    assert { :ok, _cas } = Memcache.prepend(pid, "new", "new ", [cas: true])
-    assert { :ok } = Memcache.flush(pid)
+    assert {:ok, _cas} = Memcache.prepend(pid, "new", "new ", cas: true)
+    assert {:ok} = Memcache.flush(pid)
   end
 
   def common(pid) do
-    assert { :ok } = Memcache.flush(pid)
-    assert { :ok } == Memcache.set(pid, "hello", "world")
-    assert { :ok, "world" } == Memcache.get(pid, "hello")
-    assert { :error, "Key exists" } == Memcache.add(pid, "hello", "world")
-    assert { :ok } == Memcache.replace(pid, "hello", "again")
-    assert { :ok } == Memcache.delete(pid, "hello")
-    assert { :error, "Key not found" } == Memcache.replace(pid, "hello", "world")
-    assert { :error, "Key not found" } == Memcache.get(pid, "hello")
-    assert { :error, "Key not found" } == Memcache.delete(pid, "hello")
-    assert { :ok } == Memcache.add(pid, "hello", "world")
-    assert { :ok, 3 } == Memcache.incr(pid, "count", by: 5, default: 3)
-    assert { :ok, 8 } == Memcache.incr(pid, "count", by: 5)
-    assert { :ok, 3 } == Memcache.decr(pid, "count", by: 5)
-    assert { :ok } == Memcache.delete(pid, "count")
-    assert { :ok, 0 } == Memcache.decr(pid, "count", by: 5, default: 0)
-    assert { :ok, 5 } == Memcache.incr(pid, "count", by: 5)
-    assert { :ok, 4 } == Memcache.decr(pid, "count")
-    assert { :ok, 2 } == Memcache.decr(pid, "count", by: 2)
-    assert { :ok, %{"uptime" => _}} = Memcache.stat(pid)
-    assert { :ok, %{"evictions" => "on"} } = Memcache.stat(pid, "settings")
-    assert { :ok, _version } = Memcache.version(pid)
+    assert {:ok} = Memcache.flush(pid)
+    assert {:ok} == Memcache.set(pid, "hello", "world")
+    assert {:ok, "world"} == Memcache.get(pid, "hello")
+    assert {:error, "Key exists"} == Memcache.add(pid, "hello", "world")
+    assert {:ok} == Memcache.replace(pid, "hello", "again")
+    assert {:ok} == Memcache.delete(pid, "hello")
+    assert {:error, "Key not found"} == Memcache.replace(pid, "hello", "world")
+    assert {:error, "Key not found"} == Memcache.get(pid, "hello")
+    assert {:error, "Key not found"} == Memcache.delete(pid, "hello")
+    assert {:ok} == Memcache.add(pid, "hello", "world")
+    assert {:ok, 3} == Memcache.incr(pid, "count", by: 5, default: 3)
+    assert {:ok, 8} == Memcache.incr(pid, "count", by: 5)
+    assert {:ok, 3} == Memcache.decr(pid, "count", by: 5)
+    assert {:ok} == Memcache.delete(pid, "count")
+    assert {:ok, 0} == Memcache.decr(pid, "count", by: 5, default: 0)
+    assert {:ok, 5} == Memcache.incr(pid, "count", by: 5)
+    assert {:ok, 4} == Memcache.decr(pid, "count")
+    assert {:ok, 2} == Memcache.decr(pid, "count", by: 2)
+    assert {:ok, %{"uptime" => _}} = Memcache.stat(pid)
+    assert {:ok, %{"evictions" => "on"}} = Memcache.stat(pid, "settings")
+    assert {:ok, _version} = Memcache.version(pid)
 
-    cas_error = { :error, "Key exists" }
-    assert { :ok } == Memcache.flush(pid)
-    assert { :error, "Key not found" } == Memcache.get(pid, "unknown", [cas: true])
-    assert { :ok, cas } = Memcache.set(pid, "hello", "world", [cas: true])
+    cas_error = {:error, "Key exists"}
+    assert {:ok} == Memcache.flush(pid)
+    assert {:error, "Key not found"} == Memcache.get(pid, "unknown", cas: true)
+    assert {:ok, cas} = Memcache.set(pid, "hello", "world", cas: true)
     assert is_integer(cas)
-    assert { :ok, cas } = Memcache.set_cas(pid, "hello", "world", cas, [cas: true])
-    assert { :ok } == Memcache.set(pid, "hello", "another")
-    assert cas_error == Memcache.set_cas(pid, "hello", "world", cas, [cas: true])
-    assert { :ok, "another", cas } = Memcache.get(pid, "hello", [cas: true])
-    assert { :ok, _cas } = Memcache.set_cas(pid, "hello", "world", cas, [cas: true])
-    assert { :ok } == Memcache.set(pid, "hello", "move on")
-    assert { :ok, "move on" } == Memcache.get(pid, "hello")
-    assert { :ok, cas } = Memcache.add(pid, "add", "world", [cas: true])
-    assert { :ok } == Memcache.delete_cas(pid, "add", cas)
-    assert { :ok } == Memcache.add(pid, "add", "world")
+    assert {:ok, cas} = Memcache.set_cas(pid, "hello", "world", cas, cas: true)
+    assert {:ok} == Memcache.set(pid, "hello", "another")
+    assert cas_error == Memcache.set_cas(pid, "hello", "world", cas, cas: true)
+    assert {:ok, "another", cas} = Memcache.get(pid, "hello", cas: true)
+    assert {:ok, _cas} = Memcache.set_cas(pid, "hello", "world", cas, cas: true)
+    assert {:ok} == Memcache.set(pid, "hello", "move on")
+    assert {:ok, "move on"} == Memcache.get(pid, "hello")
+    assert {:ok, cas} = Memcache.add(pid, "add", "world", cas: true)
+    assert {:ok} == Memcache.delete_cas(pid, "add", cas)
+    assert {:ok} == Memcache.add(pid, "add", "world")
     assert cas_error == Memcache.delete_cas(pid, "add", cas)
-    assert { :ok, cas } = Memcache.replace(pid, "add", "world", [cas: true])
-    assert { :ok } == Memcache.replace_cas(pid, "add", "world", cas)
+    assert {:ok, cas} = Memcache.replace(pid, "add", "world", cas: true)
+    assert {:ok} == Memcache.replace_cas(pid, "add", "world", cas)
     assert cas_error == Memcache.replace_cas(pid, "add", "world", cas)
     assert cas_error == Memcache.delete_cas(pid, "add", cas)
-    assert { :ok, "world", cas } = Memcache.get(pid, "add", [cas: true])
-    assert { :ok } == Memcache.delete_cas(pid, "add", cas)
-    assert { :ok, 5, cas } = Memcache.incr(pid, "count", [by: 1, default: 5, cas: true])
-    assert { :ok, 6 } == Memcache.incr(pid, "count", [by: 1, default: 5])
-    assert cas_error == Memcache.incr_cas(pid, "count", cas, [by: 5, default: 1])
-    assert { :ok } == Memcache.delete(pid, "count")
-    assert { :ok, 5, cas } = Memcache.decr(pid, "count", [by: 1, default: 5, cas: true])
-    assert { :ok, 4 } == Memcache.decr_cas(pid, "count", cas, [by: 1, default: 5])
-    assert cas_error == Memcache.decr_cas(pid, "count", cas, [by: 6, default: 5])
-    assert { :ok } == Memcache.delete(pid, "count")
-    assert { :ok } == Memcache.flush(pid)
+    assert {:ok, "world", cas} = Memcache.get(pid, "add", cas: true)
+    assert {:ok} == Memcache.delete_cas(pid, "add", cas)
+    assert {:ok, 5, cas} = Memcache.incr(pid, "count", by: 1, default: 5, cas: true)
+    assert {:ok, 6} == Memcache.incr(pid, "count", by: 1, default: 5)
+    assert cas_error == Memcache.incr_cas(pid, "count", cas, by: 5, default: 1)
+    assert {:ok} == Memcache.delete(pid, "count")
+    assert {:ok, 5, cas} = Memcache.decr(pid, "count", by: 1, default: 5, cas: true)
+    assert {:ok, 4} == Memcache.decr_cas(pid, "count", cas, by: 1, default: 5)
+    assert cas_error == Memcache.decr_cas(pid, "count", cas, by: 6, default: 5)
+    assert {:ok} == Memcache.delete(pid, "count")
+    assert {:ok} == Memcache.flush(pid)
 
-    assert { :ok } = Memcache.noop(pid)
-    assert { :ok } = Memcache.flush(pid)
+    assert {:ok} = Memcache.noop(pid)
+    assert {:ok} = Memcache.flush(pid)
   end
 
   def multi(pid) do
-    cas_error = { :error, "Key exists" }
-    assert { :ok } = Memcache.flush(pid)
-    assert { :ok, [{:ok}, {:ok}] } == Memcache.multi_set(pid,[{"a", "1"}, {"b", "2"}])
-    assert { :ok, [{:ok}, {:ok}] } == Memcache.multi_set(pid, %{"a" => "1", "b" => "2"})
-    assert { :ok, %{"a" => "1", "b" => "2"}} == Memcache.multi_get(pid, ["a", "b"])
-    assert { :ok, %{"a" => "1", "b" => "2"}} == Memcache.multi_get(pid, ["a", "c", "b"])
-    assert { :ok, %{"a" => {"1", _}, "b" => {"2", _}}} = Memcache.multi_get(pid, ["a", "b"], [cas: true])
-    assert { :ok, %{"a" => {"1", _}, "b" => {"2", _}}} = Memcache.multi_get(pid, ["a", "c", "b"], [cas: true])
-    assert { :ok, %{}} == Memcache.multi_get(pid, ["c"])
-    assert { :ok, %{"a" => "1"}} == Memcache.multi_get(pid, ["a"])
-    assert { :ok, [{:ok, cas_a}, {:ok, cas_b}] } = Memcache.multi_set(pid, %{"a" => "1", "b" => "2"}, cas: true)
-    assert { :ok, [{:ok}, cas_error] } == Memcache.multi_set_cas(pid, [{"a", "1", cas_a}, {"b", "1", 33}])
-    assert { :ok, [{:ok, _}] } = Memcache.multi_set_cas(pid, [{"b", "1", cas_b}], cas: true)
-    assert { :ok } = Memcache.flush(pid)
+    cas_error = {:error, "Key exists"}
+    assert {:ok} = Memcache.flush(pid)
+    assert {:ok, [{:ok}, {:ok}]} == Memcache.multi_set(pid, [{"a", "1"}, {"b", "2"}])
+    assert {:ok, [{:ok}, {:ok}]} == Memcache.multi_set(pid, %{"a" => "1", "b" => "2"})
+    assert {:ok, %{"a" => "1", "b" => "2"}} == Memcache.multi_get(pid, ["a", "b"])
+    assert {:ok, %{"a" => "1", "b" => "2"}} == Memcache.multi_get(pid, ["a", "c", "b"])
+
+    assert {:ok, %{"a" => {"1", _}, "b" => {"2", _}}} =
+             Memcache.multi_get(pid, ["a", "b"], cas: true)
+
+    assert {:ok, %{"a" => {"1", _}, "b" => {"2", _}}} =
+             Memcache.multi_get(pid, ["a", "c", "b"], cas: true)
+
+    assert {:ok, %{}} == Memcache.multi_get(pid, ["c"])
+    assert {:ok, %{"a" => "1"}} == Memcache.multi_get(pid, ["a"])
+
+    assert {:ok, [{:ok, cas_a}, {:ok, cas_b}]} =
+             Memcache.multi_set(pid, %{"a" => "1", "b" => "2"}, cas: true)
+
+    assert {:ok, [{:ok}, cas_error]} ==
+             Memcache.multi_set_cas(pid, [{"a", "1", cas_a}, {"b", "1", 33}])
+
+    assert {:ok, [{:ok, _}]} = Memcache.multi_set_cas(pid, [{"b", "1", cas_b}], cas: true)
+    assert {:ok} = Memcache.flush(pid)
   end
 
   test "commands" do
-    assert { :ok, pid } = Memcache.start_link(port: 21211)
+    assert {:ok, pid} = Memcache.start_link(port: 21211)
     common(pid)
     append_prepend(pid)
     multi(pid)
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok} = Memcache.stop(pid)
   end
 
   test "named" do
-    assert { :ok, _pid } = Memcache.start_link([port: 21211], [name: :mem])
+    assert {:ok, _pid} = Memcache.start_link([port: 21211], name: :mem)
     common(:mem)
     append_prepend(:mem)
     multi(:mem)
-    assert { :ok } = Memcache.stop(:mem)
+    assert {:ok} = Memcache.stop(:mem)
   end
 
   test "cas" do
-    assert { :ok, pid } = Memcache.start_link(port: 21211)
-    assert { :ok } == Memcache.set(pid, "counter", "0")
-    increment = fn () ->
-      Enum.each(1..100, fn (_) ->
-        Memcache.cas(pid, "counter", &(Integer.to_string(String.to_integer(&1) + 1)))
+    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok} == Memcache.set(pid, "counter", "0")
+
+    increment = fn ->
+      Enum.each(1..100, fn _ ->
+        Memcache.cas(pid, "counter", &Integer.to_string(String.to_integer(&1) + 1))
       end)
     end
+
     task_a = Task.async(increment)
     task_b = Task.async(increment)
     task_c = Task.async(increment)
@@ -137,156 +149,163 @@ defmodule MemcacheTest do
     Task.await(task_b)
     Task.await(task_c)
 
-    assert { :ok, "300" } == Memcache.get(pid, "counter")
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok, "300"} == Memcache.get(pid, "counter")
+    assert {:ok} = Memcache.stop(pid)
   end
 
   test "expire" do
-    assert { :ok, pid } = Memcache.start_link(port: 21211)
-    assert { :ok } == Memcache.flush(pid)
+    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok} == Memcache.flush(pid)
 
-    assert { :ok } == Memcache.set(pid, "set", "world", ttl: 1)
-    assert { :ok } == Memcache.set(pid, "replace", "world")
-    assert { :ok, [{:ok}, {:ok}] } == Memcache.multi_set(pid, %{"a" => "1", "b" => "2"}, ttl: 1)
-    assert { :ok, [{:ok, _}, {:ok, _}] } = Memcache.multi_set(pid, %{"c" => "1", "d" => "2"}, cas: true, ttl: 1)
-    assert { :ok } == Memcache.replace(pid, "replace", "world", ttl: 1)
-    assert { :ok } == Memcache.add(pid, "add", "world", ttl: 1)
-    assert { :ok, 5 } == Memcache.incr(pid, "incr", default: 5, ttl: 1)
-    assert { :ok, 5 } == Memcache.decr(pid, "decr", default: 5, ttl: 1)
+    assert {:ok} == Memcache.set(pid, "set", "world", ttl: 1)
+    assert {:ok} == Memcache.set(pid, "replace", "world")
+    assert {:ok, [{:ok}, {:ok}]} == Memcache.multi_set(pid, %{"a" => "1", "b" => "2"}, ttl: 1)
+
+    assert {:ok, [{:ok, _}, {:ok, _}]} =
+             Memcache.multi_set(pid, %{"c" => "1", "d" => "2"}, cas: true, ttl: 1)
+
+    assert {:ok} == Memcache.replace(pid, "replace", "world", ttl: 1)
+    assert {:ok} == Memcache.add(pid, "add", "world", ttl: 1)
+    assert {:ok, 5} == Memcache.incr(pid, "incr", default: 5, ttl: 1)
+    assert {:ok, 5} == Memcache.decr(pid, "decr", default: 5, ttl: 1)
 
     :timer.sleep(2000)
 
-    assert { :error, "Key not found" } == Memcache.get(pid, "set")
-    assert { :error, "Key not found" } == Memcache.get(pid, "replace")
-    assert { :error, "Key not found" } == Memcache.get(pid, "add")
-    assert { :error, "Key not found" } == Memcache.get(pid, "incr")
-    assert { :error, "Key not found" } == Memcache.get(pid, "decr")
-    assert { :error, "Key not found" } == Memcache.get(pid, "a")
-    assert { :error, "Key not found" } == Memcache.get(pid, "b")
-    assert { :error, "Key not found" } == Memcache.get(pid, "c")
-    assert { :error, "Key not found" } == Memcache.get(pid, "d")
+    assert {:error, "Key not found"} == Memcache.get(pid, "set")
+    assert {:error, "Key not found"} == Memcache.get(pid, "replace")
+    assert {:error, "Key not found"} == Memcache.get(pid, "add")
+    assert {:error, "Key not found"} == Memcache.get(pid, "incr")
+    assert {:error, "Key not found"} == Memcache.get(pid, "decr")
+    assert {:error, "Key not found"} == Memcache.get(pid, "a")
+    assert {:error, "Key not found"} == Memcache.get(pid, "b")
+    assert {:error, "Key not found"} == Memcache.get(pid, "c")
+    assert {:error, "Key not found"} == Memcache.get(pid, "d")
 
-
-    assert { :ok } == Memcache.set(pid, "hello", "world")
-    assert { :ok } == Memcache.flush(pid, ttl: 2)
-    assert { :ok, "world" } == Memcache.get(pid, "hello")
+    assert {:ok} == Memcache.set(pid, "hello", "world")
+    assert {:ok} == Memcache.flush(pid, ttl: 2)
+    assert {:ok, "world"} == Memcache.get(pid, "hello")
 
     :timer.sleep(3000)
 
-    assert { :error, "Key not found" } == Memcache.get(pid, "hello")
-    assert { :ok } = Memcache.stop(pid)
+    assert {:error, "Key not found"} == Memcache.get(pid, "hello")
+    assert {:ok} = Memcache.stop(pid)
   end
 
   test "namespace" do
-    assert { :ok, namespaced } = Memcache.start_link([port: 21211, namespace: "app"])
-    assert { :ok, pid } = Memcache.start_link(port: 21211)
-    assert { :ok } = Memcache.flush(pid)
-    assert { :ok } == Memcache.set(namespaced, "hello", "world")
-    assert { :error, "Key not found" } == Memcache.get(pid, "hello")
-    assert { :ok, "world" } == Memcache.get(namespaced, "hello")
-    assert { :ok, "world" } == Memcache.get(pid, "app:hello")
-    assert { :ok } == Memcache.delete(namespaced, "hello")
-    assert { :error, "Key not found" } == Memcache.get(namespaced, "hello")
-    assert { :ok } = Memcache.flush(pid)
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok, namespaced} = Memcache.start_link(port: 21211, namespace: "app")
+    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok} = Memcache.flush(pid)
+    assert {:ok} == Memcache.set(namespaced, "hello", "world")
+    assert {:error, "Key not found"} == Memcache.get(pid, "hello")
+    assert {:ok, "world"} == Memcache.get(namespaced, "hello")
+    assert {:ok, "world"} == Memcache.get(pid, "app:hello")
+    assert {:ok} == Memcache.delete(namespaced, "hello")
+    assert {:error, "Key not found"} == Memcache.get(namespaced, "hello")
+    assert {:ok} = Memcache.flush(pid)
+    assert {:ok} = Memcache.stop(pid)
 
     common(namespaced)
     append_prepend(namespaced)
     multi(namespaced)
-    assert { :ok } = Memcache.stop(namespaced)
+    assert {:ok} = Memcache.stop(namespaced)
   end
 
   test "key coder" do
     key_coder = {Test.KeyCoder, :call}
 
-    assert { :ok, coded } = Memcache.start_link([port: 21211, key_coder: key_coder])
-    assert { :ok, pid } = Memcache.start_link(port: 21211)
-    assert { :ok } = Memcache.flush(pid)
-    assert { :ok } == Memcache.set(coded, "hello", "world")
-    assert { :error, "Key not found" } == Memcache.get(pid, "hello")
-    assert { :ok, "world" } == Memcache.get(coded, "hello")
-    assert { :ok, "world" } == Memcache.get(pid, "app:hello")
-    assert { :ok } == Memcache.delete(coded, "hello")
-    assert { :error, "Key not found" } == Memcache.get(coded, "hello")
-    assert { :ok } = Memcache.flush(pid)
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok, coded} = Memcache.start_link(port: 21211, key_coder: key_coder)
+    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok} = Memcache.flush(pid)
+    assert {:ok} == Memcache.set(coded, "hello", "world")
+    assert {:error, "Key not found"} == Memcache.get(pid, "hello")
+    assert {:ok, "world"} == Memcache.get(coded, "hello")
+    assert {:ok, "world"} == Memcache.get(pid, "app:hello")
+    assert {:ok} == Memcache.delete(coded, "hello")
+    assert {:error, "Key not found"} == Memcache.get(coded, "hello")
+    assert {:ok} = Memcache.flush(pid)
+    assert {:ok} = Memcache.stop(pid)
 
     common(coded)
     append_prepend(coded)
     multi(coded)
-    assert { :ok } = Memcache.stop(coded)
+    assert {:ok} = Memcache.stop(coded)
   end
 
   test "default ttl" do
-    assert { :ok, pid } = Memcache.start_link([port: 21211, ttl: 1])
-    assert { :ok } == Memcache.flush(pid)
+    assert {:ok, pid} = Memcache.start_link(port: 21211, ttl: 1)
+    assert {:ok} == Memcache.flush(pid)
 
-    assert { :ok } == Memcache.set(pid, "set", "world")
-    assert { :ok } == Memcache.set(pid, "replace", "world")
-    assert { :ok } == Memcache.replace(pid, "replace", "world")
-    assert { :ok } == Memcache.add(pid, "add", "world")
-    assert { :ok, 5 } == Memcache.incr(pid, "incr", default: 5)
-    assert { :ok, 5 } == Memcache.decr(pid, "decr", default: 5)
-    assert { :ok, [{:ok}, {:ok}] } == Memcache.multi_set(pid, %{"a" => "1", "b" => "2"})
-    assert { :ok, [{:ok, _}, {:ok, _}] } = Memcache.multi_set(pid, %{"c" => "1", "d" => "2"}, cas: true)
+    assert {:ok} == Memcache.set(pid, "set", "world")
+    assert {:ok} == Memcache.set(pid, "replace", "world")
+    assert {:ok} == Memcache.replace(pid, "replace", "world")
+    assert {:ok} == Memcache.add(pid, "add", "world")
+    assert {:ok, 5} == Memcache.incr(pid, "incr", default: 5)
+    assert {:ok, 5} == Memcache.decr(pid, "decr", default: 5)
+    assert {:ok, [{:ok}, {:ok}]} == Memcache.multi_set(pid, %{"a" => "1", "b" => "2"})
+
+    assert {:ok, [{:ok, _}, {:ok, _}]} =
+             Memcache.multi_set(pid, %{"c" => "1", "d" => "2"}, cas: true)
 
     :timer.sleep(2000)
 
-    assert { :error, "Key not found" } == Memcache.get(pid, "set")
-    assert { :error, "Key not found" } == Memcache.get(pid, "replace")
-    assert { :error, "Key not found" } == Memcache.get(pid, "add")
-    assert { :error, "Key not found" } == Memcache.get(pid, "incr")
-    assert { :error, "Key not found" } == Memcache.get(pid, "decr")
-    assert { :error, "Key not found" } == Memcache.get(pid, "a")
-    assert { :error, "Key not found" } == Memcache.get(pid, "b")
-    assert { :error, "Key not found" } == Memcache.get(pid, "c")
-    assert { :error, "Key not found" } == Memcache.get(pid, "d")
-
+    assert {:error, "Key not found"} == Memcache.get(pid, "set")
+    assert {:error, "Key not found"} == Memcache.get(pid, "replace")
+    assert {:error, "Key not found"} == Memcache.get(pid, "add")
+    assert {:error, "Key not found"} == Memcache.get(pid, "incr")
+    assert {:error, "Key not found"} == Memcache.get(pid, "decr")
+    assert {:error, "Key not found"} == Memcache.get(pid, "a")
+    assert {:error, "Key not found"} == Memcache.get(pid, "b")
+    assert {:error, "Key not found"} == Memcache.get(pid, "c")
+    assert {:error, "Key not found"} == Memcache.get(pid, "d")
 
     common(pid)
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok} = Memcache.stop(pid)
   end
 
   test "erlang coder" do
-    assert { :ok, pid } = Memcache.start_link([port: 21211, coder: Memcache.Coder.Erlang])
+    assert {:ok, pid} = Memcache.start_link(port: 21211, coder: Memcache.Coder.Erlang)
     common(pid)
 
-    assert { :ok } == Memcache.set(pid, "hello", ["list", 1])
-    assert { :ok, ["list", 1] } == Memcache.get(pid, "hello")
-    assert { :ok, %{"hello" => ["list", 1]} } == Memcache.multi_get(pid, ["hello"])
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok} == Memcache.set(pid, "hello", ["list", 1])
+    assert {:ok, ["list", 1]} == Memcache.get(pid, "hello")
+    assert {:ok, %{"hello" => ["list", 1]}} == Memcache.multi_get(pid, ["hello"])
+    assert {:ok} = Memcache.stop(pid)
 
-    assert { :ok, pid } = Memcache.start_link([port: 21211, coder: {Memcache.Coder.Erlang, [compressed: 9]}])
-    assert { :ok } == Memcache.set(pid, "hello", ["list", 1])
-    assert { :ok, ["list", 1] } == Memcache.get(pid, "hello")
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok, pid} =
+             Memcache.start_link(port: 21211, coder: {Memcache.Coder.Erlang, [compressed: 9]})
+
+    assert {:ok} == Memcache.set(pid, "hello", ["list", 1])
+    assert {:ok, ["list", 1]} == Memcache.get(pid, "hello")
+    assert {:ok} = Memcache.stop(pid)
   end
 
   test "json coder" do
-    assert { :ok, pid } = Memcache.start_link([port: 21211, coder: Memcache.Coder.JSON])
+    assert {:ok, pid} = Memcache.start_link(port: 21211, coder: Memcache.Coder.JSON)
     common(pid)
 
-    assert { :ok } == Memcache.set(pid, "hello", ["list", 1])
-    assert { :ok, ["list", 1] } == Memcache.get(pid, "hello")
-    assert { :ok, [{:ok}] } == Memcache.multi_set(pid, [{"hello", %{ "a" => 1 }}])
-    assert { :ok, %{ "a" => 1 } } == Memcache.get(pid, "hello")
-    assert { :ok, %{"hello" => %{ "a" => 1 }} } == Memcache.multi_get(pid, ["hello"])
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok} == Memcache.set(pid, "hello", ["list", 1])
+    assert {:ok, ["list", 1]} == Memcache.get(pid, "hello")
+    assert {:ok, [{:ok}]} == Memcache.multi_set(pid, [{"hello", %{"a" => 1}}])
+    assert {:ok, %{"a" => 1}} == Memcache.get(pid, "hello")
+    assert {:ok, %{"hello" => %{"a" => 1}}} == Memcache.multi_get(pid, ["hello"])
+    assert {:ok} = Memcache.stop(pid)
 
-    assert { :ok, pid } = Memcache.start_link([port: 21211, coder: {Memcache.Coder.JSON, [keys: :atoms]}])
-    assert { :ok } == Memcache.set(pid, "hello", %{hello: "world"})
-    assert { :ok, %{hello: "world"} } == Memcache.get(pid, "hello")
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok, pid} =
+             Memcache.start_link(port: 21211, coder: {Memcache.Coder.JSON, [keys: :atoms]})
+
+    assert {:ok} == Memcache.set(pid, "hello", %{hello: "world"})
+    assert {:ok, %{hello: "world"}} == Memcache.get(pid, "hello")
+    assert {:ok} = Memcache.stop(pid)
   end
 
   test "zip coder" do
-    assert { :ok, pid } = Memcache.start_link([port: 21211, coder: Memcache.Coder.ZIP])
+    assert {:ok, pid} = Memcache.start_link(port: 21211, coder: Memcache.Coder.ZIP)
     common(pid)
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok} = Memcache.stop(pid)
   end
 
   test "reconnect" do
-    assert { :ok, pid } = Memcache.start_link(port: 21211)
+    assert {:ok, pid} = Memcache.start_link(port: 21211)
     common(pid)
     down("memcache")
     :timer.sleep(100)
@@ -294,6 +313,6 @@ defmodule MemcacheTest do
     :timer.sleep(1000)
     append_prepend(pid)
     multi(pid)
-    assert { :ok } = Memcache.stop(pid)
+    assert {:ok} = Memcache.stop(pid)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-Code.require_file "./test_utils.exs", __DIR__
+Code.require_file("./test_utils.exs", __DIR__)
 ExUnit.start(capture_log: true)
 
 defmodule Test.KeyCoder do

--- a/test/test_utils.exs
+++ b/test/test_utils.exs
@@ -1,14 +1,19 @@
 defmodule TestUtils do
   import ExUnit.Assertions
   import ExUnit.CaptureLog
+
   def assert_exit(task, expected_reason \\ :__none, timeout \\ 500) do
     Process.flag(:trap_exit, true)
-    pid = spawn_link(fn ->
-      capture_log(task)
-    end)
+
+    pid =
+      spawn_link(fn ->
+        capture_log(task)
+      end)
+
     receive do
       {:EXIT, ^pid, reason} ->
         Process.flag(:trap_exit, false)
+
         unless expected_reason == :__none do
           if Regex.regex?(expected_reason) do
             assert reason =~ expected_reason
@@ -16,9 +21,10 @@ defmodule TestUtils do
             assert reason == expected_reason
           end
         end
-    after timeout ->
+    after
+      timeout ->
         Process.flag(:trap_exit, false)
-        flunk "Failed to exit within #{timeout}"
+        flunk("Failed to exit within #{timeout}")
     end
   end
 
@@ -38,6 +44,7 @@ defmodule TestUtils do
 
   defp loop(callback) do
     callback.()
+
     receive do
       {:exit, sender} ->
         send(sender, :ok)
@@ -50,6 +57,7 @@ defmodule TestUtils do
   def stop_hammering(pids) do
     for pid <- pids do
       send(pid, {:exit, self()})
+
       receive do
         :ok -> :ok
       end


### PR DESCRIPTION
I added a `.formatter.exs` with default options, and ran the [`mix format`](https://hexdocs.pm/mix/Mix.Tasks.Format.html) command. I also made some minor readability changes to the docs to match with the formatter changes.

This eliminates quite a few compile warnings in Elixir 1.6, and also adopts the best practices used across other Elixir projects. I've been thinking of making a few contributions to this project, and thought it might be a good start to standardize the formatting a bit.

Sorry for the large change - it's mostly automatic, and the mix formatter ensures the AST stays the same when you format, so there should not be anything breaking here.