### PR TITLE
Simplify Memcache.start_link

### DIFF
--- a/lib/memcache.ex
+++ b/lib/memcache.ex
@@ -108,13 +108,14 @@ defmodule Memcache do
       |> Keyword.merge(connection_options)
       |> Keyword.update!(:coder, &normalize_coder/1)
 
-    state =
-      connection_options
-      |> Keyword.take(extra_opts)
-      |> Enum.into(%{})
+    {state, connection_options} = Keyword.split(connection_options, extra_opts)
+    {:ok, pid} = Connection.start_link(connection_options, options)
 
-    {:ok, pid} = Connection.start_link(Keyword.drop(connection_options, extra_opts), options)
-    state = Map.put(state, :connection, pid)
+    state =
+      state
+      |> Map.new()
+      |> Map.put(:connection, pid)
+
     Registry.associate(pid, state)
     {:ok, pid}
   end


### PR DESCRIPTION
Instead of doing a a [`Keyword.take/2`](https://hexdocs.pm/elixir/Keyword.html#take/2) and [`Keyword.drop/2`](https://hexdocs.pm/elixir/Keyword.html#drop/2), [`Keyword.split/2`](https://hexdocs.pm/elixir/Keyword.html#split/2) can be used to simplify things a bit.

Additionally, [`Map.new/1`](https://hexdocs.pm/elixir/Map.html#new/1) is a bit better than [`Enum.into/2`](https://hexdocs.pm/elixir/Enum.html#into/2).