### PR TITLE
Apply a linting pass using credo

### DIFF
--- a/lib/memcache/connection.ex
+++ b/lib/memcache/connection.ex
@@ -6,8 +6,8 @@ defmodule Memcache.Connection do
   require Logger
   use Connection
   alias Memcache.Protocol
-  alias Memcache.Utils
   alias Memcache.Receiver
+  alias Memcache.Utils
 
   defmodule State do
     @moduledoc false
@@ -62,13 +62,13 @@ defmodule Memcache.Connection do
     backoff_initial: 500,
     backoff_max: 30_000,
     hostname: 'localhost',
-    port: 11211
+    port: 11_211
   ]
 
   defp with_defaults(opts) do
     @default_opts
     |> Keyword.merge(opts)
-    |> Keyword.update!(:hostname, &if(is_binary(&1), do: String.to_char_list(&1), else: &1))
+    |> Keyword.update!(:hostname, &to_charlist/1)
   end
 
   @doc """
@@ -327,10 +327,10 @@ defmodule Memcache.Connection do
   end
 
   defp get_backoff(s) do
-    if !s.backoff_current do
-      s.opts[:backoff_initial]
-    else
+    if s.backoff_current do
       Utils.next_backoff(s.backoff_current, s.opts[:backoff_max])
+    else
+      s.opts[:backoff_initial]
     end
   end
 
@@ -375,10 +375,10 @@ defmodule Memcache.Connection do
       {:ok, {:ok, list}} ->
         supported = String.split(list, " ")
 
-        if !Enum.member?(supported, "PLAIN") do
-          {:stop, "Server doesn't support PLAIN authentication"}
-        else
+        if Enum.member?(supported, "PLAIN") do
           auth_plain_continue(sock, username, password)
+        else
+          {:stop, "Server doesn't support PLAIN authentication"}
         end
 
       {:ok, {:error, "Unknown command"}} ->

--- a/lib/memcache/receiver.ex
+++ b/lib/memcache/receiver.ex
@@ -80,11 +80,19 @@ defmodule Memcache.Receiver do
 
     if body_size > 0 do
       with {:ok, body, buffer} <- read(sock, buffer, body_size) do
-        response = Protocol.parse_body(header, body) |> elem(1)
+        response =
+          header
+          |> Protocol.parse_body(body)
+          |> elem(1)
+
         {:ok, response, buffer}
       end
     else
-      response = Protocol.parse_body(header, :empty) |> elem(1)
+      response =
+        header
+        |> Protocol.parse_body(:empty)
+        |> elem(1)
+
       {:ok, response, buffer}
     end
   end

--- a/lib/memcache/registry.ex
+++ b/lib/memcache/registry.ex
@@ -5,7 +5,7 @@ defmodule Memcache.Registry do
 
   ## Public interface
 
-  def start_link() do
+  def start_link do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,5 @@
 defmodule Memcache.Mixfile do
+  @moduledoc false
   use Mix.Project
 
   @version "0.4.2"

--- a/profile.exs
+++ b/profile.exs
@@ -5,7 +5,7 @@ alias Memcache.Connection
 {:ok} = Connection.execute(pid, :SET, ["hello", "world"])
 
 profile do
-  Enum.each(Range.new(0, 10000), fn _ ->
+  Enum.each(Range.new(0, 10_000), fn _ ->
     {:ok, "world"} = Connection.execute(pid, :GET, ["hello"])
   end)
 end

--- a/test/memcache/connection_test.exs
+++ b/test/memcache/connection_test.exs
@@ -1,4 +1,5 @@
 defmodule Memcache.ConnectionTest do
+  @moduledoc false
   use ExUnit.Case, async: false
   import ExUnit.CaptureLog
   import TestUtils
@@ -14,7 +15,7 @@ defmodule Memcache.ConnectionTest do
   end
 
   test "commands" do
-    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
+    {:ok, pid} = start_link(port: 21_211, hostname: "localhost")
 
     cases = [
       {:FLUSH, [], {:ok}},
@@ -81,7 +82,7 @@ defmodule Memcache.ConnectionTest do
   end
 
   test "cas commands" do
-    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
+    {:ok, pid} = start_link(port: 21_211, hostname: "localhost")
 
     cases = [
       {:FLUSH, [], [], {:ok}},
@@ -151,7 +152,7 @@ defmodule Memcache.ConnectionTest do
   end
 
   test "quiet commands" do
-    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
+    {:ok, pid} = start_link(port: 21_211, hostname: "localhost")
     {:ok} = execute(pid, :FLUSH, [])
     {:ok} = execute(pid, :SET, ["new", "hope"])
 
@@ -293,7 +294,7 @@ defmodule Memcache.ConnectionTest do
   end
 
   test "quiet cas commands" do
-    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
+    {:ok, pid} = start_link(port: 21_211, hostname: "localhost")
     {:ok} = execute(pid, :FLUSH, [])
     {:ok} = execute(pid, :SET, ["new", "hope"])
 
@@ -411,7 +412,7 @@ defmodule Memcache.ConnectionTest do
   end
 
   test "misc commands" do
-    {:ok, pid} = start_link(port: 21211, hostname: "localhost")
+    {:ok, pid} = start_link(port: 21_211, hostname: "localhost")
     {:ok, _stat} = execute(pid, :STAT, [])
     {:ok, _stat} = execute(pid, :STAT, ["items"])
     {:ok, _stat} = execute(pid, :STAT, ["slabs"])
@@ -422,7 +423,7 @@ defmodule Memcache.ConnectionTest do
   end
 
   test "named process" do
-    {:ok, pid} = start_link([port: 21211, hostname: "localhost"], name: :memcachex)
+    {:ok, pid} = start_link([port: 21_211, hostname: "localhost"], name: :memcachex)
     {:ok} = execute(:memcachex, :SET, ["hello", "world"])
     {:ok, "world"} = execute(:memcachex, :GET, ["hello"])
     {:ok} = close(pid)
@@ -430,14 +431,14 @@ defmodule Memcache.ConnectionTest do
 
   test "continue if auth is not supported" do
     assert capture_log(fn ->
-             {:ok, pid} = start_link(port: 21211, auth: {:plain, "user", "pass"})
+             {:ok, pid} = start_link(port: 21_211, auth: {:plain, "user", "pass"})
              :timer.sleep(100)
              {:ok} = close(pid)
            end) =~ "Authentication not required"
   end
 
   test "reconnects automatically" do
-    {:ok, pid} = start_link(port: 21211)
+    {:ok, pid} = start_link(port: 21_211)
     down("memcache")
     :timer.sleep(100)
     up("memcache")
@@ -448,7 +449,7 @@ defmodule Memcache.ConnectionTest do
   end
 
   test "always responds back to client" do
-    {:ok, pid} = start_link(port: 21211)
+    {:ok, pid} = start_link(port: 21_211)
     assert {:ok} = execute(pid, :SET, ["hello", "world"])
 
     pids =

--- a/test/memcache_test.exs
+++ b/test/memcache_test.exs
@@ -1,4 +1,5 @@
 defmodule MemcacheTest do
+  @moduledoc false
   use ExUnit.Case, async: false
   import TestUtils
 
@@ -117,7 +118,7 @@ defmodule MemcacheTest do
   end
 
   test "commands" do
-    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok, pid} = Memcache.start_link(port: 21_211)
     common(pid)
     append_prepend(pid)
     multi(pid)
@@ -125,7 +126,7 @@ defmodule MemcacheTest do
   end
 
   test "named" do
-    assert {:ok, _pid} = Memcache.start_link([port: 21211], name: :mem)
+    assert {:ok, _pid} = Memcache.start_link([port: 21_211], name: :mem)
     common(:mem)
     append_prepend(:mem)
     multi(:mem)
@@ -133,7 +134,7 @@ defmodule MemcacheTest do
   end
 
   test "cas" do
-    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok, pid} = Memcache.start_link(port: 21_211)
     assert {:ok} == Memcache.set(pid, "counter", "0")
 
     increment = fn ->
@@ -154,7 +155,7 @@ defmodule MemcacheTest do
   end
 
   test "expire" do
-    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok, pid} = Memcache.start_link(port: 21_211)
     assert {:ok} == Memcache.flush(pid)
 
     assert {:ok} == Memcache.set(pid, "set", "world", ttl: 1)
@@ -192,8 +193,8 @@ defmodule MemcacheTest do
   end
 
   test "namespace" do
-    assert {:ok, namespaced} = Memcache.start_link(port: 21211, namespace: "app")
-    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok, namespaced} = Memcache.start_link(port: 21_211, namespace: "app")
+    assert {:ok, pid} = Memcache.start_link(port: 21_211)
     assert {:ok} = Memcache.flush(pid)
     assert {:ok} == Memcache.set(namespaced, "hello", "world")
     assert {:error, "Key not found"} == Memcache.get(pid, "hello")
@@ -213,8 +214,8 @@ defmodule MemcacheTest do
   test "key coder" do
     key_coder = {Test.KeyCoder, :call}
 
-    assert {:ok, coded} = Memcache.start_link(port: 21211, key_coder: key_coder)
-    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok, coded} = Memcache.start_link(port: 21_211, key_coder: key_coder)
+    assert {:ok, pid} = Memcache.start_link(port: 21_211)
     assert {:ok} = Memcache.flush(pid)
     assert {:ok} == Memcache.set(coded, "hello", "world")
     assert {:error, "Key not found"} == Memcache.get(pid, "hello")
@@ -232,7 +233,7 @@ defmodule MemcacheTest do
   end
 
   test "default ttl" do
-    assert {:ok, pid} = Memcache.start_link(port: 21211, ttl: 1)
+    assert {:ok, pid} = Memcache.start_link(port: 21_211, ttl: 1)
     assert {:ok} == Memcache.flush(pid)
 
     assert {:ok} == Memcache.set(pid, "set", "world")
@@ -263,7 +264,7 @@ defmodule MemcacheTest do
   end
 
   test "erlang coder" do
-    assert {:ok, pid} = Memcache.start_link(port: 21211, coder: Memcache.Coder.Erlang)
+    assert {:ok, pid} = Memcache.start_link(port: 21_211, coder: Memcache.Coder.Erlang)
     common(pid)
 
     assert {:ok} == Memcache.set(pid, "hello", ["list", 1])
@@ -272,7 +273,7 @@ defmodule MemcacheTest do
     assert {:ok} = Memcache.stop(pid)
 
     assert {:ok, pid} =
-             Memcache.start_link(port: 21211, coder: {Memcache.Coder.Erlang, [compressed: 9]})
+             Memcache.start_link(port: 21_211, coder: {Memcache.Coder.Erlang, [compressed: 9]})
 
     assert {:ok} == Memcache.set(pid, "hello", ["list", 1])
     assert {:ok, ["list", 1]} == Memcache.get(pid, "hello")
@@ -280,7 +281,7 @@ defmodule MemcacheTest do
   end
 
   test "json coder" do
-    assert {:ok, pid} = Memcache.start_link(port: 21211, coder: Memcache.Coder.JSON)
+    assert {:ok, pid} = Memcache.start_link(port: 21_211, coder: Memcache.Coder.JSON)
     common(pid)
 
     assert {:ok} == Memcache.set(pid, "hello", ["list", 1])
@@ -291,7 +292,7 @@ defmodule MemcacheTest do
     assert {:ok} = Memcache.stop(pid)
 
     assert {:ok, pid} =
-             Memcache.start_link(port: 21211, coder: {Memcache.Coder.JSON, [keys: :atoms]})
+             Memcache.start_link(port: 21_211, coder: {Memcache.Coder.JSON, [keys: :atoms]})
 
     assert {:ok} == Memcache.set(pid, "hello", %{hello: "world"})
     assert {:ok, %{hello: "world"}} == Memcache.get(pid, "hello")
@@ -299,13 +300,13 @@ defmodule MemcacheTest do
   end
 
   test "zip coder" do
-    assert {:ok, pid} = Memcache.start_link(port: 21211, coder: Memcache.Coder.ZIP)
+    assert {:ok, pid} = Memcache.start_link(port: 21_211, coder: Memcache.Coder.ZIP)
     common(pid)
     assert {:ok} = Memcache.stop(pid)
   end
 
   test "reconnect" do
-    assert {:ok, pid} = Memcache.start_link(port: 21211)
+    assert {:ok, pid} = Memcache.start_link(port: 21_211)
     common(pid)
     down("memcache")
     :timer.sleep(100)


### PR DESCRIPTION
I fixed all the lint issues pointed out by [`credo`](https://github.com/rrrene/credo). Specifically:

### Code Readability
* Large numbers should be written with underscores.
* Do not use parentheses when defining a function which has no arguments.
* Alphabetically order aliases.
* There should be no more than 1 consecutive blank lines.

### Refactoring Opportunities
* Avoid negated conditions in if-else blocks.
* Pipe chain should start with a raw value.
* Function body is nested too deep.