### PR TITLE
Change typespec from binary() to term() in values

### DIFF
--- a/lib/memcache.ex
+++ b/lib/memcache.ex
@@ -177,7 +177,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`, `:ttl`
   """
-  @spec set(GenServer.server(), binary, binary, Keyword.t()) :: store_result
+  @spec set(GenServer.server(), binary, term, Keyword.t()) :: store_result
   def set(server, key, value, opts \\ []) do
     set_cas(server, key, value, 0, opts)
   end
@@ -188,7 +188,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`, `:ttl`
   """
-  @spec set_cas(GenServer.server(), binary, binary, integer, Keyword.t()) :: store_result
+  @spec set_cas(GenServer.server(), binary, term, integer, Keyword.t()) :: store_result
   def set_cas(server, key, value, cas, opts \\ []) do
     server_options = get_server_options(server)
 
@@ -206,7 +206,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`, `:ttl`
   """
-  @spec multi_set(GenServer.server(), [{binary, binary}] | map, Keyword.t()) ::
+  @spec multi_set(GenServer.server(), [{binary, term}] | map, Keyword.t()) ::
           {:ok, [store_result]} | error
   def multi_set(server, commands, opts \\ []) do
     commands = Enum.map(commands, fn {key, value} -> {key, value, 0} end)
@@ -218,7 +218,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`, `:ttl`
   """
-  @spec multi_set_cas(GenServer.server(), [{binary, binary, integer}], Keyword.t()) ::
+  @spec multi_set_cas(GenServer.server(), [{binary, term, integer}], Keyword.t()) ::
           {:ok, [store_result]} | error
   def multi_set_cas(server, commands, opts \\ []) do
     op = if Keyword.get(opts, :cas, false), do: :SET, else: :SETQ
@@ -271,7 +271,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`, `:ttl`
   """
-  @spec add(GenServer.server(), binary, binary, Keyword.t()) :: store_result
+  @spec add(GenServer.server(), binary, term, Keyword.t()) :: store_result
   def add(server, key, value, opts \\ []) do
     server_options = get_server_options(server)
 
@@ -290,7 +290,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`, `:ttl`
   """
-  @spec replace(GenServer.server(), binary, binary, Keyword.t()) :: store_result
+  @spec replace(GenServer.server(), binary, term, Keyword.t()) :: store_result
   def replace(server, key, value, opts \\ []) do
     replace_cas(server, key, value, 0, opts)
   end
@@ -301,7 +301,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`, `:ttl`
   """
-  @spec replace_cas(GenServer.server(), binary, binary, integer, Keyword.t()) :: store_result
+  @spec replace_cas(GenServer.server(), binary, term, integer, Keyword.t()) :: store_result
   def replace_cas(server, key, value, cas, opts \\ []) do
     server_options = get_server_options(server)
 
@@ -350,7 +350,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`
   """
-  @spec append(GenServer.server(), binary, binary, Keyword.t()) :: store_result
+  @spec append(GenServer.server(), binary, term, Keyword.t()) :: store_result
   def append(server, key, value, opts \\ []) do
     execute_kv(server, :APPEND, [key, value], opts)
   end
@@ -361,7 +361,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`
   """
-  @spec append_cas(GenServer.server(), binary, binary, integer, Keyword.t()) :: store_result
+  @spec append_cas(GenServer.server(), binary, term, integer, Keyword.t()) :: store_result
   def append_cas(server, key, value, cas, opts \\ []) do
     execute_kv(server, :APPEND, [key, value, cas], opts)
   end
@@ -373,7 +373,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`
   """
-  @spec prepend(GenServer.server(), binary, binary, Keyword.t()) :: store_result
+  @spec prepend(GenServer.server(), binary, term, Keyword.t()) :: store_result
   def prepend(server, key, value, opts \\ []) do
     execute_kv(server, :PREPEND, [key, value], opts)
   end
@@ -384,7 +384,7 @@ defmodule Memcache do
 
   Accepted options: `:cas`
   """
-  @spec prepend_cas(GenServer.server(), binary, binary, integer, Keyword.t()) :: store_result
+  @spec prepend_cas(GenServer.server(), binary, term, integer, Keyword.t()) :: store_result
   def prepend_cas(server, key, value, cas, opts \\ []) do
     execute_kv(server, :PREPEND, [key, value, cas], opts)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,7 @@ defmodule Memcache.Mixfile do
 
   def deps() do
     [
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:connection, "~> 1.0.3"},
       {:poison, "~> 2.1 or ~> 3.0 or ~> 4.0", optional: true},
       {:ex_doc, "~> 0.20.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,7 @@
   "corman": {:git, "git://github.com/EchoTeam/corman.git", "1c1ae1c0aa97ed1976d9042ac9fb805b51214661", [branch: "master"]},
   "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], []},
   "dht_ring": {:git, "git://github.com/EchoTeam/dht_ring.git", "d5b880ad76aefc81547dbb76b48a97a01d52ff41", [branch: "master"]},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "exprintf": {:hex, :exprintf, "0.1.6", "b5b0a38bf78a357dbc61cdf7364fea004af6fdf5214be44021eb2ea7edf61f6e", [:mix], []},


### PR DESCRIPTION
This is required to fix: https://github.com/ananthakumaran/memcachex/issues/20

In general:
- I've changed the specs for `value` so that it doesn't mismatch with the `term()` typespec when using the Erlang/Json encoder.
- Included dialyxir as a development dependency.