### PR TITLE
telemetry support

### DIFF
--- a/lib/memcache.ex
+++ b/lib/memcache.ex
@@ -35,6 +35,38 @@ defmodule Memcache do
   of CAS error. In case of CAS error the returned value would be equal
   to `{:error, "Key exists"}`
 
+  ## Telemetry
+
+  The following [telemetry](https://github.com/beam-telemetry/telemetry) events are published:
+
+  * `[:memcachex, :commands]` - executed for every successful commands
+    * Measurements
+      * `:elapsed_time` - (integer - native time unit) the time it took to send the commands to the server and get a reply.
+    * Metadata
+      * `:server` - (binary) hostname and port of the server
+      * `:commands` - (list) list of command
+      * `:results` - (list) list of response from the server
+      * `:start_time` - (integer - native time unit) system time when the commands were issued
+
+  * `[:memcachex, :commands_error]` - executed for every failed commands
+    * Measurements
+      * `:elapsed_time` - (integer - native time unit) the time it took to send the commands to the server and get a reply.
+    * Metadata
+      * `:server` - (binary) hostname and port of the server
+      * `:commands` - (list) list of command
+      * `:reason` - (atom) error reason
+      * `:start_time` - (integer - native time unit) system time when the commands were issued
+
+  * `[:memcachex, :connection]` - executed after successful connection.
+    * Metadata
+      * `:server` - (binary) hostname and port of the server
+      * `:reconnected` - (boolean) set to true for reconnection
+
+  * `[:memcachex, :connection_error]` - executed on connection failure.
+    * Metadata
+      * `:server` - (binary) hostname and port of the server
+      * `:reason` - (atom) error reason
+
   ## Options
 
   Most the functions in this module accept an optional `Keyword`

--- a/lib/memcache/connection.ex
+++ b/lib/memcache/connection.ex
@@ -90,7 +90,9 @@ defmodule Memcache.Connection do
   """
   @spec execute(GenServer.server(), atom, [binary], Keyword.t()) :: Memcache.result()
   def execute(pid, command, args, options \\ []) do
-    Connection.call(pid, {:execute, command, args, %{cas: Keyword.get(options, :cas, false)}})
+    with_telemetry([{command, args, options}], fn ->
+      Connection.call(pid, {:execute, command, args, %{cas: Keyword.get(options, :cas, false)}})
+    end)
   end
 
   @doc """
@@ -107,7 +109,32 @@ defmodule Memcache.Connection do
   @spec execute_quiet(GenServer.server(), [{atom, [binary]} | {atom, [binary], Keyword.t()}]) ::
           {:ok, [Memcache.result()]} | {:error, atom}
   def execute_quiet(pid, commands) do
-    Connection.call(pid, {:execute_quiet, commands})
+    with_telemetry(commands, fn ->
+      Connection.call(pid, {:execute_quiet, commands})
+    end)
+  end
+
+  defp with_telemetry(commands, callback) do
+    telemetry_metadata = %{
+      commands: commands,
+      start_time: System.system_time()
+    }
+
+    start_time = System.monotonic_time()
+    result = callback.()
+    end_time = System.monotonic_time()
+    measurements = %{elapsed_time: end_time - start_time}
+
+    case result do
+      {:error, reason} ->
+        telemetry_metadata = Map.put(telemetry_metadata, :reason, reason)
+        :ok = :telemetry.execute([:memcachex, :commands_error], %{}, telemetry_metadata)
+
+      _ ->
+        :ok = :telemetry.execute([:memcachex, :commands], measurements, telemetry_metadata)
+    end
+
+    result
   end
 
   @doc """
@@ -133,10 +160,19 @@ defmodule Memcache.Connection do
 
     case connect_and_authenticate(opts[:hostname], opts[:port], sock_opts, s) do
       {:ok, sock} ->
+        formatted_host = Utils.format_host(opts)
+        reconnected = info == :backoff || info == :reconnect
+
         _ =
-          if info == :backoff || info == :reconnect do
-            Logger.info(["Reconnected to Memcache (", Utils.format_host(opts), ")"])
+          if reconnected do
+            Logger.info(["Reconnected to Memcache (", formatted_host, ")"])
           end
+
+        :ok =
+          :telemetry.execute([:memcachex, :connection], %{}, %{
+            server: formatted_host,
+            reconnected: reconnected
+          })
 
         {:ok, receiver} = Receiver.start_link([sock, self()])
         receiver_queue = MapSet.new()
@@ -153,17 +189,24 @@ defmodule Memcache.Connection do
 
       {:error, reason} ->
         backoff = get_backoff(s)
+        formatted_host = Utils.format_host(opts)
 
         _ =
           Logger.error([
             "Failed to connect to Memcache (",
-            Utils.format_host(opts),
+            formatted_host,
             "): ",
             Utils.format_error(reason),
             ". Sleeping for ",
             to_string(backoff),
             "ms."
           ])
+
+        :ok =
+          :telemetry.execute([:memcachex, :connection_error], %{}, %{
+            server: formatted_host,
+            reason: reason
+          })
 
         {:backoff, backoff, %{s | backoff_current: backoff}}
 
@@ -173,13 +216,21 @@ defmodule Memcache.Connection do
   end
 
   def disconnect({:error, reason}, %State{opts: opts} = s) do
+    formatted_host = Utils.format_host(opts)
+
     _ =
       Logger.error([
         "Disconnected from Memcache (",
-        Utils.format_host(opts),
+        formatted_host,
         "): ",
         Utils.format_error(reason)
       ])
+
+    :ok =
+      :telemetry.execute([:memcachex, :connection_error], %{}, %{
+        server: formatted_host,
+        reason: reason
+      })
 
     cleanup(s)
 

--- a/lib/memcache/connection.ex
+++ b/lib/memcache/connection.ex
@@ -128,7 +128,7 @@ defmodule Memcache.Connection do
     case result do
       {:error, reason} ->
         telemetry_metadata = Map.put(telemetry_metadata, :reason, reason)
-        :ok = :telemetry.execute([:memcachex, :commands_error], %{}, telemetry_metadata)
+        :ok = :telemetry.execute([:memcachex, :commands_error], measurements, telemetry_metadata)
 
       _ ->
         :ok = :telemetry.execute([:memcachex, :commands], measurements, telemetry_metadata)

--- a/mix.exs
+++ b/mix.exs
@@ -22,14 +22,15 @@ defmodule Memcache.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :connection], mod: {Memcache.Application, []}]
+    [applications: [:logger, :connection, :telemetry], mod: {Memcache.Application, []}]
   end
 
   def deps() do
     [
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:connection, "~> 1.0.3"},
+      {:telemetry, "~> 0.4.0"},
       {:poison, "~> 2.1 or ~> 3.0 or ~> 4.0", optional: true},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.20.0", only: :dev},
       {:exprof, "~> 0.2.0", only: :dev},
       {:mcd, github: "EchoTeam/mcd", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -18,6 +18,7 @@
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
   "tesla": {:hex, :tesla, "0.6.0", "ede6f50c4f7d57d6787c313c30279b1d7176c362cd6f39993166375f540ec368", [:mix], [{:exjsx, ">= 0.1.0", [hex: :exjsx, optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, optional: true]}, {:hackney, "~> 1.6.0", [hex: :hackney, optional: true]}, {:ibrowse, "~> 4.2", [hex: :ibrowse, optional: true]}, {:poison, ">= 1.0.0", [hex: :poison, optional: true]}]},
   "toxiproxy": {:hex, :toxiproxy, "0.3.0", "b21c5e5a32faadc8ce0735fa30e68f37144a5f3d96b30eb524015e4598623af9", [:mix], [{:poison, ">= 1.0.0", [hex: :poison, optional: false]}, {:tesla, "~> 0.6.0", [hex: :tesla, optional: false]}]},
 }

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 Code.require_file("./test_utils.exs", __DIR__)
+TestUtils.log_telemetry_events()
 ExUnit.start(capture_log: true)
 
 defmodule Test.KeyCoder do

--- a/test/test_utils.exs
+++ b/test/test_utils.exs
@@ -1,4 +1,5 @@
 defmodule TestUtils do
+  require Logger
   import ExUnit.Assertions
   import ExUnit.CaptureLog
 
@@ -62,5 +63,25 @@ defmodule TestUtils do
         :ok -> :ok
       end
     end
+  end
+
+  def log_telemetry_events do
+    events = [
+      [:memcachex, :commands],
+      [:memcachex, :commands_error],
+      [:memcachex, :connection],
+      [:memcachex, :connection_error]
+    ]
+
+    :ok =
+      :telemetry.attach_many("memcachex-telemetry-handler", events, &handle_event/4, :no_config)
+  end
+
+  def handle_event([:memcachex, name], measurments, metadata, _config) do
+    Logger.info(
+      "Telemetry event: #{name}, measurements: #{inspect(measurments)}, metadata: #{
+        inspect(metadata)
+      }"
+    )
   end
 end


### PR DESCRIPTION
fixes #22

@stephanos Let's continue the discussion here.

* I changed the event name slightly so it's easier to pattern match on the handler

* Added `elapsed_time` to the commands_error event as well, for many CAS commands, getting errors like `Key exists` etc is a common scenario.

* Added `server` field to the connection and connection_error events.

* I am reluctant about adding `opts` and `server_options`. The main reason being it's easy to make breaking changes in the future by making changes at option normalization logic etc. I am also not sure what kind of value it brings to the table

* Agree about not having different events for reconnection. We can convey that information via metadata if required

As for things that need to be discussed further

* The way the errors are handled for execute and execute_quiet is different. For execute_quiet, we might return like `{:ok, [{:error, "Key exists"}]}`. The current code doesn't handle this, it just publishes a single commands event. I am not inclined to loop through the results. Perhaps adding the result to metadata would let the handler loop through if necessary? Ecto, for example, puts the query result in the metadata

* The `server` option is not available at execute/execute_quiet function. We can't move the logic inside any genserver as the reply is handled by different genserver. I am still thinking about how we can pass that info. Passing the server field as an extra option to execute/execute_quiet is another way to handle it.


NOTE: to view the telemetry events, set the `capture_log` field to false in test_helper and run the tests.