### PR TITLE
Relax Telemetry version constraint

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Memcache.Mixfile do
   def deps() do
     [
       {:connection, "~> 1.0.3"},
-      {:telemetry, "~> 0.4.0"},
+      {:telemetry, "~> 0.4.0 or ~> 1.0"},
       {:poison, "~> 2.1 or ~> 3.0 or ~> 4.0", optional: true},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},


### PR DESCRIPTION
Relaxes the telemetry version constraint to 1.0 to unblock updating other dependencies that specify 1.0 explicitly.
```
Resolving Hex dependencies...

Failed to use "telemetry" (version 1.0.0) because
  ecto (version 3.7.1) requires ~> 0.4 or ~> 1.0
  ecto_sql (version 3.7.0) requires ~> 0.4.0 or ~> 1.0
  joken_jwks (version 1.5.0) requires ~> 0.4.2 or ~> 1.0
  memcachex (version 0.5.1) requires ~> 0.4.0
  mix.exs specifies ~> 1.0.0
```

[There are no changes in 1.0. The version was changed to mark the stability of the API. ](https://github.com/beam-telemetry/telemetry/commit/04a1649098da2eee4856ff65ca456343fc6a0be6)