### PR TITLE
Support `:ttl` opt in `cas/4`

### DIFF
--- a/lib/memcache.ex
+++ b/lib/memcache.ex
@@ -293,7 +293,7 @@ defmodule Memcache do
     else
       @cas_error ->
         if Keyword.get(opts, :retry, true) do
-          cas(server, key, update)
+          cas(server, key, update, opts)
         else
           @cas_error
         end

--- a/lib/memcache.ex
+++ b/lib/memcache.ex
@@ -273,18 +273,22 @@ defmodule Memcache do
 
   1. Get the existing value for key
   2. If it exists, call the update function with the value
-  3. Set the returned value for key
+  3. Set the returned value for key, with optionally-provided TTL
 
   The 3rd operation will fail if someone else has updated the value
   for the same key in the mean time. In that case, by default, this
   function will go to step 1 and try again. Retry behavior can be
   disabled by passing `[retry: false]` option.
+
+  Accepted options: `:retry`, `:ttl`
   """
   @spec cas(GenServer.server(), binary, (value -> value), Keyword.t()) :: {:ok, any} | error
   def cas(server, key, update, opts \\ []) do
+    ttl_opts = Keyword.take(opts, [:ttl])
+
     with {:ok, value, cas} <- get(server, key, cas: true),
          new_value = update.(value),
-         {:ok} <- set_cas(server, key, new_value, cas) do
+         {:ok} <- set_cas(server, key, new_value, cas, ttl_opts) do
       {:ok, new_value}
     else
       @cas_error ->

--- a/test/memcache_test.exs
+++ b/test/memcache_test.exs
@@ -170,6 +170,10 @@ defmodule MemcacheTest do
     assert {:ok, 5} == Memcache.incr(pid, "incr", default: 5, ttl: 1)
     assert {:ok, 5} == Memcache.decr(pid, "decr", default: 5, ttl: 1)
 
+    assert {:ok} == Memcache.set(pid, "cas", "world", ttl: 999)
+    assert {:ok, "planet"} == Memcache.cas(pid, "cas", fn "world" -> "planet" end, ttl: 1)
+    assert {:ok, "planet"} == Memcache.get(pid, "cas")
+
     :timer.sleep(2000)
 
     assert {:error, "Key not found"} == Memcache.get(pid, "set")
@@ -177,6 +181,7 @@ defmodule MemcacheTest do
     assert {:error, "Key not found"} == Memcache.get(pid, "add")
     assert {:error, "Key not found"} == Memcache.get(pid, "incr")
     assert {:error, "Key not found"} == Memcache.get(pid, "decr")
+    assert {:error, "Key not found"} == Memcache.get(pid, "cas")
     assert {:error, "Key not found"} == Memcache.get(pid, "a")
     assert {:error, "Key not found"} == Memcache.get(pid, "b")
     assert {:error, "Key not found"} == Memcache.get(pid, "c")


### PR DESCRIPTION
Proposed change for #28.

I updated tests ~~but am not able to run them locally, sorry!~~

Thanks in advance for reviewing.